### PR TITLE
feat: Add many-to-many relationship between purchases and shops

### DIFF
--- a/app/models/purchase.py
+++ b/app/models/purchase.py
@@ -1,6 +1,13 @@
-from sqlalchemy import Column, Integer, Float, String, ForeignKey
+from sqlalchemy import Column, Integer, Float, String, ForeignKey, Table
 from sqlalchemy.orm import relationship
 from app.core.database import Base
+
+shop_purchases = Table(
+    "shop_purchases",
+    Base.metadata,
+    Column("shop_id", Integer, ForeignKey("shops.id"), primary_key=True),
+    Column("purchase_id", Integer, ForeignKey("purchases.id"), primary_key=True),
+)
 
 class Purchase(Base):
     __tablename__ = "purchases"
@@ -24,6 +31,8 @@ class Purchase(Base):
 
     delivery_type_id = Column(Integer, ForeignKey("delivery_types.id"))
     delivery_type = relationship("DeliveryType")
+
+    shops = relationship("Shop", secondary=shop_purchases, back_populates="purchases")
 
 class PurchaseItem(Base):
     __tablename__ = "purchase_items"

--- a/app/models/shop.py
+++ b/app/models/shop.py
@@ -1,6 +1,7 @@
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import relationship
 from app.core.database import Base
+from app.models.purchase import shop_purchases
 
 class Shop(Base):
     __tablename__ = "shops"
@@ -11,5 +12,5 @@ class Shop(Base):
     contact = Column(String)
     
     sales = relationship("Sale", back_populates="shop")
-    purchases = relationship("Purchase", back_populates="shop")
+    purchases = relationship("Purchase", secondary=shop_purchases, back_populates="shops")
     products = relationship("Product", secondary="shop_products", back_populates="shops")

--- a/app/schemas/purchase.py
+++ b/app/schemas/purchase.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import List, Optional
+from .shop import ShopResponse
 
 class PurchaseItemBase(BaseModel):
     product_id: int
@@ -37,7 +38,9 @@ class PurchaseBase(BaseModel):
 
 class PurchaseCreate(PurchaseBase):
     purchase_items: List[PurchaseItemCreate]
+    shop_ids: List[int]
 
 class PurchaseResponse(PurchaseBase):
     id: int
     purchase_items: List[PurchaseItemResponse]
+    shops: List[ShopResponse]

--- a/app/services/purchase.py
+++ b/app/services/purchase.py
@@ -3,6 +3,7 @@ from typing import List
 from app.models.purchase import Purchase, PurchaseItem
 from app.models.product import Product
 from app.models.product_size import ProductSize
+from app.models.shop import Shop
 from app.schemas.purchase import PurchaseCreate
 
 class PurchaseService:
@@ -24,6 +25,11 @@ class PurchaseService:
             delivery_type_id=purchase.delivery_type_id,
             purchase_items=purchase_items
         )
+
+        # Add shops to the purchase
+        if purchase.shop_ids:
+            shops = db.query(Shop).filter(Shop.id.in_(purchase.shop_ids)).all()
+            db_purchase.shops.extend(shops)
 
         # Update product quantities
         for item in purchase.purchase_items:


### PR DESCRIPTION
This commit introduces a many-to-many relationship between the `Purchase` and `Shop` models.

- A `shop_purchases` association table has been created to link shops and purchases.
- The `Purchase` and `Shop` models have been updated to reflect the many-to-many relationship.
- The `PurchaseCreate` schema now accepts a list of `shop_ids`.
- The `PurchaseResponse` schema now includes a list of associated shops.
- The `PurchaseService` has been updated to handle the creation of the associations.