### PR TITLE
fix: Add ProductSizeCreate schema to fix import error

### DIFF
--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -9,6 +9,9 @@ class ProductSizeBase(BaseModel):
     class Config:
         from_attributes = True
 
+class ProductSizeCreate(ProductSizeBase):
+    pass
+
 class ProductBase(BaseModel):
     name: str
     description: Optional[str] = None


### PR DESCRIPTION
This commit adds the `ProductSizeCreate` schema to `app/schemas/product.py` to resolve an `ImportError` in the stock service.