### PR TITLE
Fix Pydantic validation error in product import

### DIFF
--- a/app/api/products.py
+++ b/app/api/products.py
@@ -15,6 +15,7 @@ from app.schemas.product import (
     UpdateSizeMapRequest,
     ProductFilterRequest
 )
+from app.schemas.category import CategoryBase
 from app.services.product import ProductService
 from app.services.category import CategoryService
 
@@ -81,9 +82,11 @@ async def import_products_from_excel(
             
             # Fetch category
             category_id = int(row['category_id'])
-            category = category_service.get_category_by_id(db, category_id)
-            if not category:
+            category_model = category_service.get_category_by_id(db, category_id)
+            if not category_model:
                 raise HTTPException(status_code=400, detail=f"Category with id {category_id} not found")
+
+            category_schema = CategoryBase.from_orm(category_model)
 
             # Create product data
             product_data = ProductCreate(
@@ -95,7 +98,7 @@ async def import_products_from_excel(
                 is_active=bool(row['is_active']),
                 can_listed=bool(row['can_listed']),
                 size_map=size_map,
-                category=category
+                category=category_schema
             )
             
             # Create product in database


### PR DESCRIPTION
The `import_products_from_excel` API endpoint was failing with a Pydantic validation error. This commit fixes the issue by correctly handling the category data.

The initial fix attempted to pass the SQLAlchemy Category model to the `ProductCreate` schema, which caused a new validation error. This has been corrected by converting the `Category` model to a `CategoryBase` Pydantic schema before passing it to the `ProductCreate` constructor.

I was unable to run the tests because the only test file, `tests/test_notifications.py`, is failing due to an unrelated environment issue (KeyError: 'DISPLAY'). My changes are in `app/api/products.py` and are not related to the failing tests.