### PR TITLE
feat: Create vendor on purchase if vendor_id is 0

### DIFF
--- a/app/schemas/purchase.py
+++ b/app/schemas/purchase.py
@@ -37,6 +37,10 @@ class PurchaseBase(BaseModel):
 class PurchaseCreate(PurchaseBase):
     purchase_items: List[PurchaseItemCreate]
     shop_ids: List[int]
+    supplier_name: Optional[str] = None
+    supplier_address: Optional[str] = None
+    supplier_mobile: Optional[str] = None
+    supplier_email: Optional[str] = None
 
 class PurchaseResponse(PurchaseBase):
     id: int

--- a/app/services/purchase.py
+++ b/app/services/purchase.py
@@ -5,9 +5,22 @@ from app.models.product import Product
 from app.models.product_size import ProductSize
 from app.models.shop import Shop
 from app.schemas.purchase import PurchaseCreate
+from app.schemas.vendor import VendorCreate
+from app.services.vendor import create_vendor
 
 class PurchaseService:
     def create_purchase(self, db: Session, purchase: PurchaseCreate) -> Purchase:
+        vendor_id = purchase.vendor_id
+        if vendor_id == 0:
+            vendor_data = VendorCreate(
+                name=purchase.supplier_name,
+                address=purchase.supplier_address,
+                mobile=purchase.supplier_mobile,
+                email=purchase.supplier_email
+            )
+            new_vendor = create_vendor(db, vendor_data)
+            vendor_id = new_vendor.id
+
         # Create PurchaseItem models from the purchase data
         purchase_items = [PurchaseItem(**item.dict()) for item in purchase.purchase_items]
 
@@ -19,7 +32,7 @@ class PurchaseService:
             payment_type_id=purchase.payment_type_id,
             payment_reference_number=purchase.payment_reference_number,
             delivery_type_id=purchase.delivery_type_id,
-            vendor_id=purchase.vendor_id,
+            vendor_id=vendor_id,
             purchase_items=purchase_items
         )
 


### PR DESCRIPTION
This commit introduces functionality to create a new vendor during the purchase process if the provided `vendor_id` is 0.

- The `PurchaseCreate` schema in `app/schemas/purchase.py` has been updated to include optional supplier details (`supplier_name`, `supplier_address`, `supplier_mobile`, `supplier_email`).
- The `create_purchase` service in `app/services/purchase.py` now checks for a `vendor_id` of 0. If found, it creates a new vendor with the provided details and uses the new `vendor_id` for the purchase.
- This allows for a more streamlined workflow where vendors can be created on-the-fly when adding a new purchase.