### PR TITLE
feat: add purchase data to dashboard

### DIFF
--- a/app/schemas/dashboard.py
+++ b/app/schemas/dashboard.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import Dict, List
 from app.schemas.sale import SaleResponse
+from app.schemas.purchase import PurchaseResponse
 
 class Dashboard(BaseModel):
     total_sales: Dict
@@ -8,6 +9,8 @@ class Dashboard(BaseModel):
     total_categories: int
     most_sold_items: Dict
     recent_sales: List[SaleResponse]
+    total_purchases: Dict
+    recent_purchases: List[PurchaseResponse]
     
     class Config:
         from_attributes = True

--- a/app/services/dashboard.py
+++ b/app/services/dashboard.py
@@ -3,12 +3,14 @@ from typing import Dict
 from app.services.sale import SaleService
 from app.services.product import ProductService
 from app.services.category import CategoryService
+from app.services.purchase import PurchaseService
 
 class DashboardService:
     def __init__(self):
         self.sale_service = SaleService()
         self.product_service = ProductService()
         self.category_service = CategoryService()
+        self.purchase_service = PurchaseService()
 
     def get_dashboard_data(self, db: Session) -> Dict:
         return {
@@ -16,5 +18,7 @@ class DashboardService:
             "total_products": len(self.product_service.get_all_products(db)),
             "total_categories": len(self.category_service.get_all_categories(db)),
             "most_sold_items": self.sale_service.get_most_sold_items(db),
-            "recent_sales": self.sale_service.get_recent_sales(db)
+            "recent_sales": self.sale_service.get_recent_sales(db),
+            "total_purchases": self.purchase_service.get_total_purchases(db),
+            "recent_purchases": self.purchase_service.get_recent_purchases(db)
         }

--- a/app/services/purchase.py
+++ b/app/services/purchase.py
@@ -79,3 +79,15 @@ class PurchaseService:
 
     def get_purchase_by_id(self, db: Session, purchase_id: int) -> Purchase:
         return db.query(Purchase).filter(Purchase.id == purchase_id).first()
+
+    def get_recent_purchases(self, db: Session, limit: int = 10) -> List[Purchase]:
+        return db.query(Purchase).order_by(Purchase.date.desc()).limit(limit).all()
+
+    def get_total_purchases(self, db: Session) -> dict:
+        """Get total purchases summary"""
+        purchases = self.get_all_purchases(db)
+        return {
+            'total_count': len(purchases),
+            'total_cost': sum(purchase.total_price for purchase in purchases),
+            'total_items_purchased': sum(purchase.total_quantity for purchase in purchases)
+        }


### PR DESCRIPTION
This commit updates the dashboard to include data from purchases.

- Adds `get_total_purchases` and `get_recent_purchases` to `PurchaseService`.
- Updates the `Dashboard` schema to include `total_purchases` and `recent_purchases`.
- Updates the `DashboardService` to fetch and include purchase data in the dashboard response.