### PR TITLE
Fix: Dynamically generate product image URLs to prevent 404 errors

### DIFF
--- a/app/services/product.py
+++ b/app/services/product.py
@@ -1,3 +1,4 @@
+import os
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from fastapi import HTTPException
@@ -7,6 +8,23 @@ from app.models.product_size import ProductSize
 from app.schemas.product import ProductCreate, ProductUpdate, UpdateSizeMapRequest
 
 class ProductService:
+    def _get_correct_image_url(self, product_id: int) -> Optional[str]:
+        image_dir = f"images/products/{product_id}"
+        if not os.path.isdir(image_dir):
+            return None
+        try:
+            files = [f for f in os.listdir(image_dir) if os.path.isfile(os.path.join(image_dir, f))]
+            if not files:
+                return None
+            files.sort()
+            return f"/{image_dir}/{files[0]}"
+        except FileNotFoundError:
+            return None
+
+    def _apply_correct_image_url(self, product: Optional[Product]):
+        if product:
+            product.image_url = self._get_correct_image_url(product.id)
+
     def create_product(self, db: Session, product: ProductCreate) -> Product:
         db_product = Product(
             name=product.name,
@@ -29,13 +47,19 @@ class ProductService:
         db.add(db_product)
         db.commit()
         db.refresh(db_product)
+        self._apply_correct_image_url(db_product)
         return db_product
 
     def get_all_products(self, db: Session) -> List[Product]:
-        return db.query(Product).all()
+        products = db.query(Product).all()
+        for product in products:
+            self._apply_correct_image_url(product)
+        return products
 
     def get_product_by_id(self, db: Session, product_id: int) -> Optional[Product]:
-        return db.query(Product).filter(Product.id == product_id).first()
+        product = db.query(Product).filter(Product.id == product_id).first()
+        self._apply_correct_image_url(product)
+        return product
 
     def update_product(self, db: Session, product_update: ProductUpdate) -> Optional[Product]:
         db_product = self.get_product_by_id(db, product_update.id)
@@ -47,6 +71,7 @@ class ProductService:
             
         db.commit()
         db.refresh(db_product)
+        self._apply_correct_image_url(db_product)
         return db_product
 
     def update_size_map(self, db: Session, update_request: UpdateSizeMapRequest) -> Optional[Product]:
@@ -67,6 +92,7 @@ class ProductService:
             
         db.commit()
         db.refresh(db_product)
+        self._apply_correct_image_url(db_product)
         return db_product
 
     def get_filtered_products(
@@ -84,7 +110,10 @@ class ProductService:
             # Add any specific filtering logic based on product type
             pass
             
-        return query.all()
+        products = query.all()
+        for p in products:
+            self._apply_correct_image_url(p)
+        return products
 
     def update_product_image_url(self, db: Session, product_id: int, image_url: str) -> Optional[Product]:
         db_product = self.get_product_by_id(db, product_id)
@@ -94,6 +123,7 @@ class ProductService:
         db_product.image_url = image_url
         db.commit()
         db.refresh(db_product)
+        self._apply_correct_image_url(db_product)
         return db_product
 
     def update_product_stock(


### PR DESCRIPTION
This change addresses an issue where incorrect image URLs were being sent to the client, resulting in 404 Not Found errors. The root cause appears to be data inconsistency, where the image URL stored in the database does not match the actual image file on the server.

To make the system more resilient, this commit modifies the `ProductService` to dynamically generate the image URL based on the files present in the product's image directory. A helper function has been added to scan the filesystem and construct a valid URL, which is now used in all API responses that include product information. This ensures that the client always receives a correct and working image link.