### PR TITLE
feat: Use environment variables for Google Drive auth

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,13 +1,22 @@
 import os
+from pydantic_settings import BaseSettings
 
-class Settings:
+class Settings(BaseSettings):
     # Email settings
-    MAIL_USERNAME = os.getenv("MAIL_USERNAME", "adrenalinesportsstore44@gmail.com")
-    MAIL_PASSWORD = os.getenv("MAIL_PASSWORD", "oajy ubuh epgr dkrs")
-    MAIL_FROM = os.getenv("MAIL_FROM", "adrenalinesportsstore44@gmail.com")
-    MAIL_PORT = int(os.getenv("MAIL_PORT", 587))
-    MAIL_SERVER = os.getenv("MAIL_SERVER", "smtp.gmail.com")
-    MAIL_TLS = os.getenv("MAIL_TLS", "True").lower() in ("true", "1", "t")
-    MAIL_SSL = os.getenv("MAIL_SSL", "False").lower() in ("true", "1", "t")
+    MAIL_USERNAME: str = "adrenalinesportsstore44@gmail.com"
+    MAIL_PASSWORD: str = "oajy ubuh epgr dkrs"
+    MAIL_FROM: str = "adrenalinesportsstore44@gmail.com"
+    MAIL_PORT: int = 587
+    MAIL_SERVER: str = "smtp.gmail.com"
+    MAIL_TLS: bool = True
+    MAIL_SSL: bool = False
+
+    # Google Drive settings
+    GOOGLE_CLIENT_ID: str
+    GOOGLE_CLIENT_SECRET: str
+    GOOGLE_REDIRECT_URIS: str = "http://localhost:8080/"
+
+    class Config:
+        env_file = ".env"
 
 settings = Settings()

--- a/app/core/google_drive.py
+++ b/app/core/google_drive.py
@@ -1,15 +1,29 @@
 from pydrive2.auth import GoogleAuth
 from pydrive2.drive import GoogleDrive
 import os
+from app.core.config import settings
 
 class GoogleDriveService:
-    def __init__(self, client_secrets_path='client_secrets.json', credentials_path='mycreds.txt'):
-        self.client_secrets_path = client_secrets_path
+    def __init__(self, credentials_path='mycreds.txt'):
         self.credentials_path = credentials_path
         self.drive = self._authenticate()
 
     def _authenticate(self):
         gauth = GoogleAuth()
+
+        # Create the settings dictionary from environment variables
+        client_config = {
+            "client_id": settings.GOOGLE_CLIENT_ID,
+            "client_secret": settings.GOOGLE_CLIENT_SECRET,
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "redirect_uris": [settings.GOOGLE_REDIRECT_URIS],
+            "access_type": "offline",
+        }
+
+        # Manually set the client config
+        gauth.client_config = {'web': client_config}
+
         # Try to load saved client credentials
         gauth.LoadCredentialsFile(self.credentials_path)
         if gauth.credentials is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ pandas==2.1.3
 numpy==1.26.4
 openpyxl==3.1.2
 PyDrive2
+pydantic-settings
 pytest


### PR DESCRIPTION
This commit updates the Google Drive authentication to use environment variables instead of a `client_secrets.json` file.

The main changes are:
- Added `pydantic-settings` to `requirements.txt`.
- Updated `app/core/config.py` to include Google Drive credentials and use `pydantic-settings`.
- Modified `app/core/google_drive.py` to use the new settings from `app/core/config.py` for authentication.
- Added a dummy `.env` file for testing purposes.