### PR TITLE
fix: Serve static images

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,11 @@
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI(title="SSMS API")
+
+# Mount the 'images' directory to serve static files
+app.mount("/images", StaticFiles(directory="images"), name="images")
 
 # Configure CORS
 app.add_middleware(


### PR DESCRIPTION
This commit configures the application to serve static files from the `images` directory. This is necessary to be able to view the uploaded product images.