### PR TITLE
feat: Add pass_key authentication to system APIs

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -1,21 +1,62 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
 import sys
 import os
+from pydantic import BaseModel
 
 # Add the root directory to the Python path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
 from reset_db import reset_database
+from app.core.config import settings
 
 router = APIRouter()
 
+class PassKey(BaseModel):
+    pass_key: str
+
 @router.post("/reset-db", tags=["system"])
-async def reset_db_endpoint():
+async def reset_db_endpoint(item: PassKey):
     """
     Resets the entire database by dropping all tables, recreating them, and seeding initial data.
     """
+    if item.pass_key != settings.SYSTEM_PASS_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid pass_key",
+        )
     try:
         reset_database()
         return {"message": "Database reset successfully!"}
     except Exception as e:
-        return {"message": f"An error occurred during database reset: {e}"}
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"An error occurred during database reset: {e}"
+        )
+
+@router.post("/backup-db", tags=["system"])
+async def backup_db_endpoint(item: PassKey):
+    """
+    Creates a backup of the database.
+    Requires a valid pass_key.
+    """
+    if item.pass_key != settings.SYSTEM_PASS_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid pass_key",
+        )
+    # Placeholder for backup logic
+    return {"message": "Backup functionality not implemented yet."}
+
+@router.post("/restore-db", tags=["system"])
+async def restore_db_endpoint(item: PassKey):
+    """
+    Restores the database from a backup.
+    Requires a valid pass_key.
+    """
+    if item.pass_key != settings.SYSTEM_PASS_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid pass_key",
+        )
+    # Placeholder for restore logic
+    return {"message": "Restore functionality not implemented yet."}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     MAIL_SERVER: str = "smtp.gmail.com"
     MAIL_TLS: bool = True
     MAIL_SSL: bool = False
+    SYSTEM_PASS_KEY: str = "your_secret_pass_key"
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
Adds a `pass_key` authentication mechanism to the system-level APIs to protect sensitive operations.

- A `SYSTEM_PASS_KEY` has been added to the application settings in `app/core/config.py`, which can be configured via environment variables.
- The `/reset-db` endpoint in `app/api/system.py` now requires a `pass_key` in the request body for authentication.
- New placeholder endpoints, `/backup-db` and `/restore-db`, have been added with the same `pass_key` authentication. These endpoints currently return a "Not Implemented" message.
- Error handling for the system APIs has been improved to return proper HTTP status codes.