### PR TITLE
feat: Generalize offer activation endpoint

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -31,12 +31,13 @@ async def update_event_offer(
         raise HTTPException(status_code=404, detail="Offer not found")
     return updated_offer
 
-@router.put("/deactivate/{offer_id}", response_model=EventOfferResponse)
-async def deactivate_event_offer(
+@router.put("/set_active_status/{offer_id}", response_model=EventOfferResponse)
+async def set_event_offer_active_status(
     offer_id: int,
+    is_active: bool,
     db: Session = Depends(get_db)
 ):
-    deactivated_offer = event_offer_service.deactivate_event_offer(db, offer_id)
-    if not deactivated_offer:
+    updated_offer = event_offer_service.set_event_offer_active_status(db, offer_id, is_active)
+    if not updated_offer:
         raise HTTPException(status_code=404, detail="Offer not found")
-    return deactivated_offer
+    return updated_offer

--- a/app/services/event.py
+++ b/app/services/event.py
@@ -64,13 +64,17 @@ class EventOfferService:
         db.refresh(db_offer)
         return db_offer
 
-    def deactivate_event_offer(self, db: Session, offer_id: int) -> Optional[EventOffer]:
+    def set_event_offer_active_status(self, db: Session, offer_id: int, is_active: bool) -> Optional[EventOffer]:
         db_offer = self.get_event_offer_by_id(db, offer_id)
         if not db_offer:
             return None
 
-        db_offer.is_active = False
-        self.remove_offer_from_products(db, db_offer.product_ids, db_offer.category_ids)
+        db_offer.is_active = is_active
+
+        if is_active:
+            self.apply_offer_to_products(db, db_offer)
+        else:
+            self.remove_offer_from_products(db, db_offer.product_ids, db_offer.category_ids)
 
         db.add(db_offer)
         db.commit()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -90,7 +90,7 @@ class TestEvents(unittest.TestCase):
         self.assertEqual(self.mock_product_2.discounted_price, 180) # 200 - 20
 
     @patch('app.services.event.ProductService')
-    def test_deactivate_event_offer(self, MockProductService):
+    def test_set_active_status_deactivate(self, MockProductService):
         # Arrange
         mock_product_service = MockProductService.return_value
         mock_product_service.get_product_by_id.side_effect = self.mock_get_product_by_id
@@ -102,11 +102,31 @@ class TestEvents(unittest.TestCase):
         self.db_session.query(EventOffer).filter.return_value.first.return_value = mock_offer
 
         # Act
-        self.event_offer_service.deactivate_event_offer(self.db_session, 1)
+        self.event_offer_service.set_event_offer_active_status(self.db_session, 1, is_active=False)
 
         # Assert
         self.assertEqual(mock_offer.is_active, False)
         self.assertEqual(self.mock_product_1.offer_id, None)
+
+    @patch('app.services.event.ProductService')
+    def test_set_active_status_activate(self, MockProductService):
+        # Arrange
+        mock_product_service = MockProductService.return_value
+        mock_product_service.get_product_by_id.side_effect = self.mock_get_product_by_id
+
+        mock_offer = EventOffer(
+            id=1, name="Inactive Offer", is_active=False,
+            rate_type=RateType.flat, rate=10,
+            product_ids="1", category_ids=""
+        )
+        self.db_session.query(EventOffer).filter.return_value.first.return_value = mock_offer
+
+        # Act
+        self.event_offer_service.set_event_offer_active_status(self.db_session, 1, is_active=True)
+
+        # Assert
+        self.assertEqual(mock_offer.is_active, True)
+        self.assertEqual(self.mock_product_1.discounted_price, 90)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit refactors the offer deactivation functionality to handle both activation and deactivation of events and offers.

Changes include:
- The service method `deactivate_event_offer` has been renamed to `set_event_offer_active_status` and now accepts a boolean to set the desired state.
- The API endpoint has been changed from `PUT /events/deactivate/{offer_id}` to `PUT /events/set_active_status/{offer_id}?is_active=...` to provide a more flexible interface.
- The business logic has been updated to apply the offer to products on activation and remove it on deactivation.
- The test suite has been updated to include tests for both activating and deactivating an offer, ensuring the new logic is covered.