### PR TITLE
Refactor the end_day endpoint to no longer require cash_in_hand and c…

### DIFF
--- a/app/api/day_management.py
+++ b/app/api/day_management.py
@@ -35,9 +35,9 @@ def get_expenses(day_id: int, db: Session = Depends(get_db)):
     return day_management_service.get_expenses_for_day(db, day_id)
 
 @router.post("/endDay/{day_id}", response_model=DaySummary)
-def end_day(day_id: int, cash_in_hand: float, cash_in_account: float, db: Session = Depends(get_db)):
+def end_day(day_id: int, db: Session = Depends(get_db)):
     try:
-        day_management_service.end_day(db, day_id, cash_in_hand, cash_in_account)
+        day_management_service.end_day(db, day_id)
         return day_management_service.get_day_summary(db, day_id)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
…ash_in_account as parameters.

The endpoint now calculates these values by summing the total price of sales for the day, differentiating between 'Cash' and other payment types.

This change simplifies the API and moves the business logic of calculating end-of-day totals to the service layer.