### PR TITLE
feat: Implement database backup to GitHub

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, HTTPException, status
 import sys
 import os
 from pydantic import BaseModel
+import subprocess
+import datetime
+from app.core.database import POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, POSTGRES_SERVER
 
 # Add the root directory to the Python path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
@@ -36,7 +39,7 @@ async def reset_db_endpoint(item: PassKey):
 @router.post("/backup-db", tags=["system"])
 async def backup_db_endpoint(item: PassKey):
     """
-    Creates a backup of the database.
+    Creates a backup of the database and uploads it to a GitHub repository.
     Requires a valid pass_key.
     """
     if item.pass_key != settings.SYSTEM_PASS_KEY:
@@ -44,8 +47,59 @@ async def backup_db_endpoint(item: PassKey):
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid pass_key",
         )
-    # Placeholder for backup logic
-    return {"message": "Backup functionality not implemented yet."}
+
+    try:
+        # --- Database Backup ---
+        backup_dir = "backups"
+        os.makedirs(backup_dir, exist_ok=True)
+
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        backup_file = os.path.join(backup_dir, f"backup_{timestamp}.sql")
+
+        pg_dump_cmd = [
+            "pg_dump",
+            "-h", POSTGRES_SERVER,
+            "-U", POSTGRES_USER,
+            "-d", POSTGRES_DB,
+            "-f", backup_file
+        ]
+
+        env = os.environ.copy()
+        env["PGPASSWORD"] = POSTGRES_PASSWORD
+
+        subprocess.run(pg_dump_cmd, check=True, env=env)
+
+        # --- GitHub Upload ---
+        repo_url = settings.GITHUB_REPO_URL
+        token = settings.GITHUB_TOKEN
+
+        repo_name = repo_url.split("/")[-1].replace(".git", "")
+        repo_dir = os.path.join(backup_dir, repo_name)
+
+        if not os.path.exists(repo_dir):
+            clone_url = repo_url.replace("https://", f"https://{token}@")
+            subprocess.run(["git", "clone", clone_url, repo_dir], check=True)
+
+        backup_filename = os.path.basename(backup_file)
+        new_backup_path = os.path.join(repo_dir, backup_filename)
+        os.rename(backup_file, new_backup_path)
+
+        subprocess.run(["git", "-C", repo_dir, "add", new_backup_path], check=True)
+        subprocess.run(["git", "-C", repo_dir, "commit", "-m", f"Add backup {timestamp}"], check=True)
+        subprocess.run(["git", "-C", repo_dir, "push"], check=True)
+
+        return {"message": f"Backup created and uploaded successfully: {backup_filename}"}
+
+    except subprocess.CalledProcessError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"An error occurred during the backup process: {e}"
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"An unexpected error occurred: {e}"
+        )
 
 @router.post("/restore-db", tags=["system"])
 async def restore_db_endpoint(item: PassKey):

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -13,6 +13,11 @@ class Settings(BaseSettings):
     MAIL_SSL: bool = False
     SYSTEM_PASS_KEY: str = os.getenv("SYSTEM_PASS_KEY", "7736")
 
+    # Github settings
+    GITHUB_REPO_URL: Optional[str] = os.getenv("GITHUB_REPO_URL", "https://github.com/adrenalines-sports/ssms-db-backup.git")
+    GITHUB_TOKEN: Optional[str] = os.getenv("GITHUB_TOKEN", None)
+
+
     class Config:
         env_file = ".env"
         extra = 'ignore'


### PR DESCRIPTION
This change implements the `backup_db_endpoint` to create a backup of the PostgreSQL database and upload it to a GitHub repository.

- Uses `pg_dump` to create a SQL dump of the database.
- Uses `git` commands to clone a repository, add the backup file, commit, and push.
- Adds `GITHUB_REPO_URL` and `GITHUB_TOKEN` to the settings.
- Includes error handling for the backup and upload process.