### PR TITLE
feat: Add endpoint to run SQL fix script

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -10,6 +10,7 @@ from app.core.database import POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, POS
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
 from reset_db import reset_database
+from run_sql_fix import run_sql_fix
 from app.core.config import settings
 
 router = APIRouter()
@@ -114,3 +115,24 @@ async def restore_db_endpoint(item: PassKey):
         )
     # Placeholder for restore logic
     return {"message": "Restore functionality not implemented yet."}
+
+
+@router.post("/run-sql-fix", tags=["system"])
+async def run_sql_fix_endpoint(item: PassKey):
+    """
+    Executes the SQL fix script.
+    Requires a valid pass_key.
+    """
+    if item.pass_key != settings.SYSTEM_PASS_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid pass_key",
+        )
+    try:
+        run_sql_fix()
+        return {"message": "SQL fix script executed successfully!"}
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"An error occurred during SQL fix execution: {e}"
+        )


### PR DESCRIPTION
This commit introduces a new endpoint `/system/run-sql-fix` that allows triggering the execution of the `run_sql_fix.py` script.

The endpoint is protected by the same `pass_key` mechanism as other system endpoints.

The `run_sql_fix.py` script is designed to apply a specific SQL patch from the `fix_update0822.sql` file. This endpoint provides a convenient way to apply this fix via an API call.