### PR TITLE
feat: Add stock hold and release functionality

### DIFF
--- a/app/api/stock.py
+++ b/app/api/stock.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, UploadFile, File
 from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.services.stock import StockService
+from app.schemas.stock import StockRequest, StockResponse
 
 router = APIRouter()
 
@@ -9,3 +10,13 @@ router = APIRouter()
 async def upload_excel(file: UploadFile = File(...), db: Session = Depends(get_db)):
     stock_service = StockService()
     return await stock_service.upload_excel(db, file)
+
+@router.post("/hold", response_model=StockResponse)
+def hold_stock(stock_request: StockRequest, db: Session = Depends(get_db)):
+    stock_service = StockService()
+    return stock_service.hold_stock(db, stock_request)
+
+@router.post("/release", response_model=StockResponse)
+def release_stock(stock_request: StockRequest, db: Session = Depends(get_db)):
+    stock_service = StockService()
+    return stock_service.release_stock(db, stock_request)

--- a/app/schemas/stock.py
+++ b/app/schemas/stock.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+class StockItem(BaseModel):
+    product_id: int
+    size: str
+    quantity: int
+
+class StockRequest(BaseModel):
+    items: List[StockItem]
+
+class StockResponse(BaseModel):
+    success: bool
+    message: Optional[str] = None


### PR DESCRIPTION
This commit introduces new API endpoints and services to manage stock levels.

- Adds `/api/stock/hold` to decrease stock for a list of items.
- Adds `/api/stock/release` to increase stock for a list of items.
- Creates `StockRequest` and `StockResponse` Pydantic models for the new endpoints.
- Implements `hold_stock` and `release_stock` methods in the `StockService` to handle the business logic.