### PR TITLE
feat: Add check stock API endpoint

### DIFF
--- a/app/api/stock.py
+++ b/app/api/stock.py
@@ -20,3 +20,8 @@ def hold_stock(stock_request: StockRequest, db: Session = Depends(get_db)):
 def release_stock(stock_request: StockRequest, db: Session = Depends(get_db)):
     stock_service = StockService()
     return stock_service.release_stock(db, stock_request)
+
+@router.post("/check", response_model=StockResponse)
+def check_stock(stock_request: StockRequest, db: Session = Depends(get_db)):
+    stock_service = StockService()
+    return stock_service.check_stock(db, stock_request)

--- a/app/schemas/stock.py
+++ b/app/schemas/stock.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional
 
 class StockItem(BaseModel):
-    product_id: int
+    product_id: int = Field(..., alias='productId')
     size: str
     quantity: int
 


### PR DESCRIPTION
This commit introduces a new API endpoint `/api/stock/check` to verify stock availability for a list of items.

- Adds a `check_stock` method to the `StockService` to handle the business logic of checking stock without modifying the database.
- Creates a new POST endpoint `/api/stock/check` in the stock router.
- Updates the `StockItem` Pydantic schema to use an alias for `productId` to correctly map the incoming request from the frontend.