### PR TITLE
Add Day Management History API

### DIFF
--- a/app/api/day_management.py
+++ b/app/api/day_management.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from typing import List, Optional
 
@@ -98,6 +98,23 @@ def get_day_summary(day_id: int, db: Session = Depends(get_db), current_user: Us
     check_shop_access(current_user, db_day.shop_id)
     try:
         return day_management_service.get_day_summary(db, day_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@router.get("/history", response_model=List[DaySummary])
+def get_day_history(
+    start_date: str = Query(..., description="Start date in YYYY-MM-DD format"),
+    end_date: str = Query(..., description="End date in YYYY-MM-DD format"),
+    shop_id: Optional[int] = Query(None, description="Shop ID (admin only)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Retrieve day management history for a date range."""
+    if current_user.role != "admin":
+        shop_id = current_user.shop_id
+
+    try:
+        return day_management_service.get_days_range(db, start_date, end_date, shop_id)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/app/services/day_management.py
+++ b/app/services/day_management.py
@@ -255,7 +255,16 @@ class DayManagementService:
         if not db_day:
             raise Exception("Day not found.")
 
-        expenses = self.get_expenses_for_day(db, day_id)
+        if db_day.end_time is None:
+            self._populate_live_totals(db, db_day)
+
+        return self._get_day_summary_from_obj(db, db_day)
+
+    def _get_day_summary_from_obj(self, db: Session, db_day: Day) -> DaySummary:
+        """
+        Generates a DaySummary schema from a Day model instance.
+        """
+        expenses = self.get_expenses_for_day(db, db_day.id)
         shop_name = db_day.shop.name if db_day.shop else "Unknown"
         day_date = db_day.start_time.date().isoformat() if db_day.start_time else None
 
@@ -281,6 +290,25 @@ class DayManagementService:
             end_time=db_day.end_time,
             message="Day summary retrieved successfully."
         )
+
+    def get_days_range(self, db: Session, start_date: str, end_date: str, shop_id: Optional[int] = None) -> List[DaySummary]:
+        """
+        Retrieves day summaries for a date range and optional shop.
+        """
+        query = db.query(Day).filter(
+            cast(Day.start_time, Date) >= date.fromisoformat(start_date),
+            cast(Day.start_time, Date) <= date.fromisoformat(end_date)
+        )
+        if shop_id:
+            query = query.filter(Day.shop_id == shop_id)
+
+        days = query.order_by(Day.start_time.desc()).all()
+        summaries = []
+        for day in days:
+            if day.end_time is None:
+                self._populate_live_totals(db, day)
+            summaries.append(self._get_day_summary_from_obj(db, day))
+        return summaries
 
     def get_all_shops_status(self, db: Session) -> list:
         """

--- a/tests/test_day_management_history.py
+++ b/tests/test_day_management_history.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, date
+from app.services.day_management import DayManagementService
+from app.models.day_management import Day, Expense
+from app.models.shop import Shop
+
+class TestDayManagementHistory(unittest.TestCase):
+
+    def setUp(self):
+        self.day_service = DayManagementService()
+        self.db = MagicMock()
+
+    def test_get_days_range(self):
+        # Arrange
+        start_date = "2023-01-01"
+        end_date = "2023-01-10"
+        shop_id = 1
+
+        shop = Shop(id=shop_id, name="Test Shop")
+        day1 = Day(id=1, shop_id=shop_id, start_time=datetime(2023, 1, 1, 10, 0), end_time=datetime(2023, 1, 1, 20, 0), opening_balance=100.0, shop=shop)
+        day2 = Day(id=2, shop_id=shop_id, start_time=datetime(2023, 1, 2, 10, 0), end_time=None, opening_balance=200.0, shop=shop)
+
+        mock_query = self.db.query.return_value.filter.return_value.filter.return_value.order_by.return_value
+        mock_query.all.return_value = [day2, day1]
+
+        # Mocking _populate_live_totals to avoid actual DB calls for live data
+        with patch.object(self.day_service, '_populate_live_totals') as mock_populate:
+            with patch.object(self.day_service, 'get_expenses_for_day') as mock_expenses:
+                mock_expenses.return_value = []
+
+                # Act
+                results = self.day_service.get_days_range(self.db, start_date, end_date, shop_id)
+
+                # Assert
+                self.assertEqual(len(results), 2)
+                self.assertEqual(results[0].day_id, 2)
+                self.assertEqual(results[1].day_id, 1)
+                self.assertTrue(results[0].day_started)
+                self.assertFalse(results[0].day_ended)
+                self.assertTrue(results[1].day_ended)
+                mock_populate.assert_called_once_with(self.db, day2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have implemented a new API endpoint for retrieving day management history.

Key changes:
- **Service Layer**: Added `get_days_range` to `DayManagementService` in `app/services/day_management.py`. This method retrieves `DaySummary` objects for all shops (admin) or a specific shop within a date range.
- **API Layer**: Added a new `GET /history` endpoint in `app/api/day_management.py`. It accepts `start_date`, `end_date`, and an optional `shop_id`.
- **Consistency**: Refactored existing day summary retrieval to use a standardized helper method, ensuring "live" totals are correctly populated for ongoing days.
- **Access Control**: Staff users are automatically restricted to their own shop's history, while admins can query any shop or all shops.
- **Testing**: Created a new test suite `tests/test_day_management_history.py` and verified the service logic.

---
*PR created automatically by Jules for task [621486307272541054](https://jules.google.com/task/621486307272541054) started by @azeez148*