### PR TITLE
Implement Campaign V2 Management APIs

### DIFF
--- a/alembic/versions/d2e3f4g5h6i7_add_campaign_v2_tables.py
+++ b/alembic/versions/d2e3f4g5h6i7_add_campaign_v2_tables.py
@@ -1,0 +1,91 @@
+"""add campaign v2 tables
+
+Revision ID: d2e3f4g5h6i7
+Revises: bc21107894a0
+Create Date: 2026-06-02 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd2e3f4g5h6i7'
+down_revision = 'bc21107894a0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table('campaigns_v2',
+    sa.Column('id', sa.String(), nullable=False),
+    sa.Column('title', sa.String(), nullable=False),
+    sa.Column('description', sa.Text(), nullable=True),
+    sa.Column('type', sa.Enum('survey', 'giveaway', 'discount', 'prediction', 'lucky_draw', name='campaigntypev2'), nullable=True),
+    sa.Column('status', sa.Enum('draft', 'active', 'paused', 'ended', 'scheduled', 'closed', 'results_announced', name='campaignstatusv2'), nullable=True),
+    sa.Column('start_date', sa.DateTime(), nullable=True),
+    sa.Column('end_date', sa.DateTime(), nullable=True),
+    sa.Column('image_url', sa.String(), nullable=True),
+    sa.Column('rules', sa.JSON(), nullable=True),
+    sa.Column('terms_and_conditions', sa.Text(), nullable=True),
+    sa.Column('winners', sa.JSON(), nullable=True),
+    sa.Column('results_summary', sa.Text(), nullable=True),
+    sa.Column('meta_data', sa.JSON(), nullable=True),
+    sa.Column('created_date', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+    sa.Column('updated_date', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('created_by', sa.String(), nullable=True),
+    sa.Column('updated_by', sa.String(), nullable=True),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_campaigns_v2_id'), 'campaigns_v2', ['id'], unique=False)
+
+    op.create_table('campaign_fields',
+    sa.Column('id', sa.String(), nullable=False),
+    sa.Column('campaign_id', sa.String(), nullable=True),
+    sa.Column('label', sa.String(), nullable=False),
+    sa.Column('type', sa.Enum('text', 'number', 'email', 'select', 'textarea', 'choice', name='fieldtype'), nullable=True),
+    sa.Column('required', sa.Boolean(), nullable=True),
+    sa.Column('options', sa.JSON(), nullable=True),
+    sa.Column('order', sa.Integer(), nullable=True),
+    sa.Column('created_date', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+    sa.Column('updated_date', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('created_by', sa.String(), nullable=True),
+    sa.Column('updated_by', sa.String(), nullable=True),
+    sa.ForeignKeyConstraint(['campaign_id'], ['campaigns_v2.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_campaign_fields_id'), 'campaign_fields', ['id'], unique=False)
+
+    op.create_table('campaign_participations',
+    sa.Column('id', sa.String(), nullable=False),
+    sa.Column('campaign_id', sa.String(), nullable=True),
+    sa.Column('user_id', sa.String(), nullable=True),
+    sa.Column('participation_date', sa.DateTime(), server_default=sa.func.now(), nullable=True),
+    sa.Column('responses', sa.JSON(), nullable=True),
+    sa.Column('status', sa.Enum('SUBMITTED', 'WINNER', 'PARTICIPATED', name='participationstatus'), nullable=True),
+    sa.Column('created_date', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+    sa.Column('updated_date', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('created_by', sa.String(), nullable=True),
+    sa.Column('updated_by', sa.String(), nullable=True),
+    sa.ForeignKeyConstraint(['campaign_id'], ['campaigns_v2.id'], ),
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_campaign_participations_id'), 'campaign_participations', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_campaign_participations_id'), table_name='campaign_participations')
+    op.drop_table('campaign_participations')
+    op.drop_index(op.f('ix_campaign_fields_id'), table_name='campaign_fields')
+    op.drop_table('campaign_fields')
+    op.drop_index(op.f('ix_campaigns_v2_id'), table_name='campaigns_v2')
+    op.drop_table('campaigns_v2')
+
+    # Optional: Drop types if needed for Postgres
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        sa.Enum(name='campaigntypev2').drop(bind)
+        sa.Enum(name='campaignstatusv2').drop(bind)
+        sa.Enum(name='fieldtype').drop(bind)
+        sa.Enum(name='participationstatus').drop(bind)

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -120,3 +120,13 @@ async def admin_login(login_data: LoginRequest, db: Session = Depends(get_db)):
         expires_delta=timedelta(days=7)
     )
     return AuthResponse(token=access_token, user=user)
+
+async def get_current_user_admin(
+    current_user: User = Depends(get_current_user)
+) -> User:
+    if current_user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Operation not permitted"
+        )
+    return current_user

--- a/app/api/campaign_v2.py
+++ b/app/api/campaign_v2.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from typing import List, Optional
 
@@ -7,16 +7,36 @@ from app.api.auth import get_current_user
 from app.models.user import User
 from app.schemas.campaign import (
     CampaignV2Response, CampaignParticipationCreate, CampaignParticipationResponse,
-    CampaignResultsResponse
+    CampaignResultsResponse, CreateCampaignRequestV2, UpdateCampaignRequestV2,
+    PatchCampaignRequestV2, CampaignListResponseV2, CampaignResultsV2,
+    CampaignStatsV2, BulkActionRequestV2, BulkActionResponseV2
 )
 from app.services.campaign import CampaignService
+from app.api.auth import get_current_user_admin
+import pandas as pd
+import tempfile
+import os
+from fastapi.responses import FileResponse
+from starlette.background import BackgroundTask
 
 router = APIRouter()
 campaign_service = CampaignService()
 
-@router.get("", response_model=List[CampaignV2Response])
-async def list_campaigns(status: Optional[str] = None, db: Session = Depends(get_db)):
-    return campaign_service.get_campaigns_v2(db, status)
+@router.get("", response_model=CampaignListResponseV2)
+async def list_campaigns(
+    status: Optional[str] = None,
+    search: Optional[str] = None,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(10, ge=1),
+    db: Session = Depends(get_db)
+):
+    campaigns, total = campaign_service.get_campaigns_v2_admin(db, page, per_page, status, search)
+    return {
+        "items": campaigns,
+        "total": total,
+        "page": page,
+        "per_page": per_page
+    }
 
 @router.get("/active", response_model=List[CampaignV2Response])
 async def get_active_campaigns(db: Session = Depends(get_db)):
@@ -62,9 +82,128 @@ async def get_my_campaign_participation(
     participation = campaign_service.get_my_participation_v2(db, id, str(current_user.id))
     return participation
 
-@router.get("/{id}/results", response_model=CampaignResultsResponse)
+@router.get("/{id}/results", response_model=CampaignResultsV2)
 async def get_campaign_results(id: str, db: Session = Depends(get_db)):
     results = campaign_service.get_campaign_results_v2(db, id)
     if not results:
         raise HTTPException(status_code=404, detail="Campaign not found")
     return results
+
+@router.get("/stats", response_model=CampaignStatsV2)
+async def get_campaign_stats(db: Session = Depends(get_db), current_user: User = Depends(get_current_user_admin)):
+    return campaign_service.get_campaign_stats_v2(db)
+
+@router.post("", response_model=CampaignV2Response)
+async def create_campaign(
+    campaign: CreateCampaignRequestV2,
+    current_user: User = Depends(get_current_user_admin),
+    db: Session = Depends(get_db)
+):
+    return campaign_service.create_campaign_v2(db, campaign.model_dump(by_alias=True), str(current_user.id))
+
+@router.put("/{id}", response_model=CampaignV2Response)
+async def update_campaign(
+    id: str,
+    campaign: UpdateCampaignRequestV2,
+    current_user: User = Depends(get_current_user_admin),
+    db: Session = Depends(get_db)
+):
+    updated = campaign_service.update_campaign_v2(db, id, campaign.model_dump(exclude_unset=True, by_alias=True), str(current_user.id))
+    if not updated:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    return updated
+
+@router.patch("/{id}", response_model=CampaignV2Response)
+async def patch_campaign(
+    id: str,
+    updates: PatchCampaignRequestV2,
+    current_user: User = Depends(get_current_user_admin),
+    db: Session = Depends(get_db)
+):
+    updated = campaign_service.patch_campaign_v2(db, id, updates.model_dump(exclude_unset=True, by_alias=True), str(current_user.id))
+    if not updated:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    return updated
+
+@router.delete("/{id}")
+async def delete_campaign(
+    id: str,
+    current_user: User = Depends(get_current_user_admin),
+    db: Session = Depends(get_db)
+):
+    if not campaign_service.delete_campaign_v2(db, id):
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    return {"message": "Campaign deleted"}
+
+@router.post("/{id}/publish", response_model=CampaignV2Response)
+async def publish_campaign(
+    id: str,
+    force_data: dict = {},
+    current_user: User = Depends(get_current_user_admin),
+    db: Session = Depends(get_db)
+):
+    from app.models.campaign import CampaignStatusV2
+    updated = campaign_service.patch_campaign_v2(db, id, {"status": CampaignStatusV2.ACTIVE}, str(current_user.id))
+    if not updated:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    return updated
+
+@router.post("/{id}/unpublish", response_model=CampaignV2Response)
+async def unpublish_campaign(
+    id: str,
+    current_user: User = Depends(get_current_user_admin),
+    db: Session = Depends(get_db)
+):
+    from app.models.campaign import CampaignStatusV2
+    updated = campaign_service.patch_campaign_v2(db, id, {"status": CampaignStatusV2.PAUSED}, str(current_user.id))
+    if not updated:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    return updated
+
+@router.get("/{id}/export")
+async def export_campaign_data(id: str, format: str = "csv", db: Session = Depends(get_db), current_user: User = Depends(get_current_user_admin)):
+    from app.models.campaign import CampaignParticipation
+    participations = db.query(CampaignParticipation).filter(CampaignParticipation.campaign_id == id).all()
+
+    data = []
+    for p in participations:
+        row = {
+            "participation_id": p.id,
+            "user_id": p.user_id,
+            "participation_date": p.participation_date,
+            "status": p.status
+        }
+        row.update(p.responses)
+        data.append(row)
+
+    df = pd.DataFrame(data)
+
+    suffix = ".csv" if format == "csv" else ".xlsx"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        if format == "csv":
+            df.to_csv(tmp.name, index=False)
+        else:
+            df.to_excel(tmp.name, index=False)
+        tmp_path = tmp.name
+
+    return FileResponse(tmp_path, filename=f"campaign_{id}_export{suffix}", background=BackgroundTask(os.unlink, tmp_path))
+
+@router.post("/bulk/publish", response_model=BulkActionResponseV2)
+async def bulk_publish(request: BulkActionRequestV2, db: Session = Depends(get_db), current_user: User = Depends(get_current_user_admin)):
+    return campaign_service.bulk_action_v2(db, request.ids, 'publish', request.force, str(current_user.id))
+
+@router.post("/bulk/unpublish", response_model=BulkActionResponseV2)
+async def bulk_unpublish(request: BulkActionRequestV2, db: Session = Depends(get_db), current_user: User = Depends(get_current_user_admin)):
+    return campaign_service.bulk_action_v2(db, request.ids, 'unpublish', request.force, str(current_user.id))
+
+@router.post("/bulk/delete", response_model=BulkActionResponseV2)
+async def bulk_delete(request: BulkActionRequestV2, db: Session = Depends(get_db), current_user: User = Depends(get_current_user_admin)):
+    return campaign_service.bulk_action_v2(db, request.ids, 'delete', request.force, str(current_user.id))
+
+@router.post("/bulk/pause", response_model=BulkActionResponseV2)
+async def bulk_pause(request: BulkActionRequestV2, db: Session = Depends(get_db), current_user: User = Depends(get_current_user_admin)):
+    return campaign_service.bulk_action_v2(db, request.ids, 'pause', request.force, str(current_user.id))
+
+@router.post("/bulk/action", response_model=BulkActionResponseV2)
+async def bulk_action(request: BulkActionRequestV2, db: Session = Depends(get_db), current_user: User = Depends(get_current_user_admin)):
+    return campaign_service.bulk_action_v2(db, request.ids, request.action, request.force, str(current_user.id))

--- a/app/models/campaign.py
+++ b/app/models/campaign.py
@@ -32,15 +32,22 @@ class RecipientType(str, enum.Enum):
 
 # V2 Enums
 class CampaignTypeV2(str, enum.Enum):
-    PREDICTION = "PREDICTION"
-    GIVEAWAY = "GIVEAWAY"
-    LUCKY_DRAW = "LUCKY_DRAW"
-    SURVEY = "SURVEY"
+    SURVEY = "survey"
+    GIVEAWAY = "giveaway"
+    DISCOUNT = "discount"
+    # Keeping old ones for backward compatibility if needed, but the task implies a transition
+    PREDICTION = "prediction"
+    LUCKY_DRAW = "lucky_draw"
 
 class CampaignStatusV2(str, enum.Enum):
-    ACTIVE = "ACTIVE"
-    CLOSED = "CLOSED"
-    RESULTS_ANNOUNCED = "RESULTS_ANNOUNCED"
+    DRAFT = "draft"
+    ACTIVE = "active"
+    PAUSED = "paused"
+    ENDED = "ended"
+    SCHEDULED = "scheduled"
+    # Keeping old ones
+    CLOSED = "closed"
+    RESULTS_ANNOUNCED = "results_announced"
 
 class FieldType(str, enum.Enum):
     text = "text"
@@ -48,6 +55,7 @@ class FieldType(str, enum.Enum):
     email = "email"
     select = "select"
     textarea = "textarea"
+    choice = "choice"
 
 class ParticipationStatus(str, enum.Enum):
     SUBMITTED = "SUBMITTED"
@@ -150,7 +158,7 @@ class CampaignV2(BaseModel):
     title = Column(String, nullable=False)
     description = Column(Text)
     type = Column(Enum(CampaignTypeV2))
-    status = Column(Enum(CampaignStatusV2), default=CampaignStatusV2.ACTIVE)
+    status = Column(Enum(CampaignStatusV2), default=CampaignStatusV2.DRAFT)
     start_date = Column(DateTime)
     end_date = Column(DateTime)
     image_url = Column(String)
@@ -158,6 +166,7 @@ class CampaignV2(BaseModel):
     terms_and_conditions = Column(Text)
     winners = Column(JSON) # List of winner names/IDs
     results_summary = Column(Text)
+    meta_data = Column(JSON)
 
     fields = relationship("CampaignField", back_populates="campaign", cascade="all, delete-orphan")
     participations = relationship("CampaignParticipation", back_populates="campaign", cascade="all, delete-orphan")
@@ -171,6 +180,7 @@ class CampaignField(BaseModel):
     type = Column(Enum(FieldType))
     required = Column(Boolean, default=True)
     options = Column(JSON) # Array of strings for select type
+    order = Column(Integer, default=0)
 
     campaign = relationship("CampaignV2", back_populates="fields")
 

--- a/app/schemas/campaign.py
+++ b/app/schemas/campaign.py
@@ -14,6 +14,7 @@ class CampaignFieldSchema(BaseModel):
     type: FieldType
     required: bool = True
     options: Optional[List[str]] = None
+    order: Optional[int] = 0
 
     class Config:
         from_attributes = True
@@ -32,10 +33,68 @@ class CampaignV2Response(BaseModel):
     fields: List[CampaignFieldSchema]
     winners: Optional[List[str]] = None
     results_summary: Optional[str] = Field(None, alias="resultsSummary")
+    metadata: Optional[Dict[str, Any]] = Field(None, alias="metadata", validation_alias="meta_data")
+    participation_count: Optional[int] = Field(0, alias="participationCount")
+    submission_count: Optional[int] = Field(0, alias="submissionCount")
+    created_by: Optional[str] = Field(None, alias="createdBy")
+    created_at: Optional[datetime] = Field(None, alias="createdAt")
+    updated_by: Optional[str] = Field(None, alias="updatedBy")
+    updated_at: Optional[datetime] = Field(None, alias="updatedAt")
 
     class Config:
         populate_by_name = True
         from_attributes = True
+
+class CampaignQuestionV2(BaseModel):
+    type: FieldType
+    label: str
+    options: Optional[List[str]] = None
+    required: bool = True
+    order: Optional[int] = 0
+
+class CreateCampaignRequestV2(BaseModel):
+    title: str
+    description: str
+    type: CampaignTypeV2
+    status: CampaignStatusV2
+    starts_at: datetime = Field(..., alias="starts_at")
+    ends_at: datetime = Field(..., alias="ends_at")
+    metadata: Optional[Dict[str, Any]] = None
+    questions: Optional[List[CampaignQuestionV2]] = None
+
+    class Config:
+        populate_by_name = True
+
+class UpdateCampaignRequestV2(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    type: Optional[CampaignTypeV2] = None
+    status: Optional[CampaignStatusV2] = None
+    starts_at: Optional[datetime] = Field(None, alias="starts_at")
+    ends_at: Optional[datetime] = Field(None, alias="ends_at")
+    metadata: Optional[Dict[str, Any]] = None
+    questions: Optional[List[CampaignQuestionV2]] = None
+
+    class Config:
+        populate_by_name = True
+
+class PatchCampaignRequestV2(BaseModel):
+    status: Optional[CampaignStatusV2] = None
+    starts_at: Optional[datetime] = Field(None, alias="starts_at")
+    ends_at: Optional[datetime] = Field(None, alias="ends_at")
+    force: Optional[bool] = False
+
+    class Config:
+        populate_by_name = True
+
+class CampaignListResponseV2(BaseModel):
+    items: List[CampaignV2Response]
+    page: int
+    per_page: int = Field(..., alias="per_page")
+    total: int
+
+    class Config:
+        populate_by_name = True
 
 class CampaignParticipationCreate(BaseModel):
     responses: Dict[str, Any]
@@ -52,6 +111,16 @@ class CampaignParticipationResponse(BaseModel):
         populate_by_name = True
         from_attributes = True
 
+class CampaignResultsV2(BaseModel):
+    campaign_id: str = Field(..., alias="campaign_id")
+    total_participations: int = Field(..., alias="total_participations")
+    responses: Dict[str, Dict[str, int]]
+    from_date: Optional[str] = Field(None, alias="from")
+    to_date: Optional[str] = Field(None, alias="to")
+
+    class Config:
+        populate_by_name = True
+
 class CampaignResultsResponse(BaseModel):
     winners: List[str]
     results_summary: Optional[str] = Field(None, alias="resultsSummary")
@@ -59,6 +128,25 @@ class CampaignResultsResponse(BaseModel):
     class Config:
         populate_by_name = True
         from_attributes = True
+
+class CampaignStatsV2(BaseModel):
+    totalCampaigns: int
+    activeCampaigns: int
+    draftCampaigns: int
+    totalParticipations: int
+    completionRate: float
+
+    class Config:
+        populate_by_name = True
+
+class BulkActionRequestV2(BaseModel):
+    ids: List[str]
+    action: str # 'publish' | 'unpublish' | 'delete' | 'pause'
+    force: Optional[bool] = False
+
+class BulkActionResponseV2(BaseModel):
+    success: List[str]
+    failed: List[Dict[str, str]] # [{id: string, error: string}]
 
 # V1 Schemas
 class CampaignQuestionBase(BaseModel):

--- a/app/services/campaign.py
+++ b/app/services/campaign.py
@@ -6,7 +6,7 @@ from sqlalchemy import or_, func
 from app.models.campaign import (
     Campaign, CampaignQuestion, CampaignParticipant,
     CampaignWinner, CampaignCommunication, CampaignStatus, SubmissionStatus,
-    CampaignV2, CampaignField, CampaignParticipation, CampaignStatusV2
+    CampaignV2, CampaignField, CampaignParticipation, CampaignStatusV2, ParticipationStatus
 )
 from app.schemas.campaign import (
     CampaignCreate, CampaignUpdate, CampaignQuestionCreate,
@@ -278,13 +278,194 @@ class CampaignService:
         query = db.query(CampaignV2)
         if status:
             query = query.filter(CampaignV2.status == status)
-        return query.all()
+
+        campaigns = query.all()
+        for c in campaigns:
+            c.participation_count = db.query(CampaignParticipation).filter(CampaignParticipation.campaign_id == c.id).count()
+            c.submission_count = db.query(CampaignParticipation).filter(
+                CampaignParticipation.campaign_id == c.id,
+                CampaignParticipation.status == ParticipationStatus.SUBMITTED
+            ).count()
+        return campaigns
+
+    def get_campaigns_v2_admin(self, db: Session, page: int = 1, per_page: int = 10,
+                             status: Optional[str] = None, search: Optional[str] = None) -> Tuple[List[CampaignV2], int]:
+        query = db.query(CampaignV2)
+        if status:
+            query = query.filter(CampaignV2.status == status)
+        if search:
+            query = query.filter(CampaignV2.title.ilike(f"%{search}%"))
+
+        total = query.count()
+        campaigns = query.offset((page - 1) * per_page).limit(per_page).all()
+
+        for c in campaigns:
+            c.participation_count = db.query(CampaignParticipation).filter(CampaignParticipation.campaign_id == c.id).count()
+            c.submission_count = db.query(CampaignParticipation).filter(
+                CampaignParticipation.campaign_id == c.id,
+                CampaignParticipation.status == ParticipationStatus.SUBMITTED
+            ).count()
+
+        return campaigns, total
 
     def get_active_campaigns_v2(self, db: Session) -> List[CampaignV2]:
-        return db.query(CampaignV2).filter(CampaignV2.status == CampaignStatusV2.ACTIVE).all()
+        campaigns = db.query(CampaignV2).filter(CampaignV2.status == CampaignStatusV2.ACTIVE).all()
+        for c in campaigns:
+            c.participation_count = db.query(CampaignParticipation).filter(CampaignParticipation.campaign_id == c.id).count()
+            c.submission_count = db.query(CampaignParticipation).filter(
+                CampaignParticipation.campaign_id == c.id,
+                CampaignParticipation.status == ParticipationStatus.SUBMITTED
+            ).count()
+        return campaigns
 
     def get_campaign_v2_by_id(self, db: Session, campaign_id: str) -> Optional[CampaignV2]:
-        return db.query(CampaignV2).filter(CampaignV2.id == campaign_id).first()
+        c = db.query(CampaignV2).filter(CampaignV2.id == campaign_id).first()
+        if c:
+            c.participation_count = db.query(CampaignParticipation).filter(CampaignParticipation.campaign_id == c.id).count()
+            c.submission_count = db.query(CampaignParticipation).filter(
+                CampaignParticipation.campaign_id == c.id,
+                CampaignParticipation.status == ParticipationStatus.SUBMITTED
+            ).count()
+        return c
+
+    def create_campaign_v2(self, db: Session, campaign_data: dict, user_id: Optional[str] = None) -> CampaignV2:
+        import uuid
+        questions = campaign_data.pop('questions', [])
+
+        # Map starts_at/ends_at to start_date/end_date
+        if 'starts_at' in campaign_data:
+            campaign_data['start_date'] = campaign_data.pop('starts_at')
+        if 'ends_at' in campaign_data:
+            campaign_data['end_date'] = campaign_data.pop('ends_at')
+
+        if 'metadata' in campaign_data:
+            campaign_data['meta_data'] = campaign_data.pop('metadata')
+
+        campaign_id = str(uuid.uuid4())
+        db_campaign = CampaignV2(id=campaign_id, **campaign_data, created_by=user_id)
+        db.add(db_campaign)
+
+        for q in questions:
+            field_id = str(uuid.uuid4())
+            db_field = CampaignField(id=field_id, campaign_id=campaign_id, **q)
+            db.add(db_field)
+
+        db.commit()
+        db.refresh(db_campaign)
+        return self.get_campaign_v2_by_id(db, campaign_id)
+
+    def update_campaign_v2(self, db: Session, campaign_id: str, campaign_data: dict, user_id: Optional[str] = None) -> Optional[CampaignV2]:
+        db_campaign = db.query(CampaignV2).filter(CampaignV2.id == campaign_id).first()
+        if not db_campaign:
+            return None
+
+        questions = campaign_data.pop('questions', None)
+
+        if 'starts_at' in campaign_data:
+            campaign_data['start_date'] = campaign_data.pop('starts_at')
+        if 'ends_at' in campaign_data:
+            campaign_data['end_date'] = campaign_data.pop('ends_at')
+
+        if 'metadata' in campaign_data:
+            campaign_data['meta_data'] = campaign_data.pop('metadata')
+
+        for key, value in campaign_data.items():
+            setattr(db_campaign, key, value)
+
+        db_campaign.updated_by = user_id
+
+        if questions is not None:
+            # Overwrite fields
+            db.query(CampaignField).filter(CampaignField.campaign_id == campaign_id).delete()
+            import uuid
+            for q in questions:
+                field_id = str(uuid.uuid4())
+                db_field = CampaignField(id=field_id, campaign_id=campaign_id, **q)
+                db.add(db_field)
+
+        db.commit()
+        db.refresh(db_campaign)
+        return self.get_campaign_v2_by_id(db, campaign_id)
+
+    def patch_campaign_v2(self, db: Session, campaign_id: str, patch_data: dict, user_id: Optional[str] = None) -> Optional[CampaignV2]:
+        db_campaign = db.query(CampaignV2).filter(CampaignV2.id == campaign_id).first()
+        if not db_campaign:
+            return None
+
+        if 'starts_at' in patch_data:
+            patch_data['start_date'] = patch_data.pop('starts_at')
+        if 'ends_at' in patch_data:
+            patch_data['end_date'] = patch_data.pop('ends_at')
+
+        if 'metadata' in patch_data:
+            patch_data['meta_data'] = patch_data.pop('metadata')
+
+        force = patch_data.pop('force', False)
+
+        for key, value in patch_data.items():
+            if value is not None:
+                setattr(db_campaign, key, value)
+
+        db_campaign.updated_by = user_id
+        db.commit()
+        db.refresh(db_campaign)
+        return self.get_campaign_v2_by_id(db, campaign_id)
+
+    def delete_campaign_v2(self, db: Session, campaign_id: str) -> bool:
+        db_campaign = db.query(CampaignV2).filter(CampaignV2.id == campaign_id).first()
+        if not db_campaign:
+            return False
+        db.delete(db_campaign)
+        db.commit()
+        return True
+
+    def get_campaign_stats_v2(self, db: Session) -> dict:
+        total_campaigns = db.query(CampaignV2).count()
+        active_campaigns = db.query(CampaignV2).filter(CampaignV2.status == CampaignStatusV2.ACTIVE).count()
+        draft_campaigns = db.query(CampaignV2).filter(CampaignV2.status == CampaignStatusV2.DRAFT).count()
+        total_participations = db.query(CampaignParticipation).count()
+
+        # Calculate completion rate
+        total_submissions = db.query(CampaignParticipation).filter(CampaignParticipation.status == ParticipationStatus.SUBMITTED).count()
+        completion_rate = (total_submissions / total_participations * 100) if total_participations > 0 else 0
+
+        return {
+            "totalCampaigns": total_campaigns,
+            "activeCampaigns": active_campaigns,
+            "draftCampaigns": draft_campaigns,
+            "totalParticipations": total_participations,
+            "completionRate": completion_rate
+        }
+
+    def bulk_action_v2(self, db: Session, ids: List[str], action: str, force: bool = False, user_id: Optional[str] = None) -> dict:
+        success = []
+        failed = []
+
+        for campaign_id in ids:
+            try:
+                db_campaign = db.query(CampaignV2).filter(CampaignV2.id == campaign_id).first()
+                if not db_campaign:
+                    failed.append({"id": campaign_id, "error": "Not found"})
+                    continue
+
+                if action == 'publish':
+                    db_campaign.status = CampaignStatusV2.ACTIVE
+                elif action == 'unpublish':
+                    db_campaign.status = CampaignStatusV2.PAUSED
+                elif action == 'pause':
+                    db_campaign.status = CampaignStatusV2.PAUSED
+                elif action == 'delete':
+                    db.delete(db_campaign)
+
+                if db_campaign:
+                    db_campaign.updated_by = user_id
+
+                success.append(campaign_id)
+            except Exception as e:
+                failed.append({"id": campaign_id, "error": str(e)})
+
+        db.commit()
+        return {"success": success, "failed": failed}
 
     def participate_v2(self, db: Session, campaign_id: str, user_id: str, responses: dict) -> CampaignParticipation:
         import uuid
@@ -331,9 +512,22 @@ class CampaignService:
         db_campaign = self.get_campaign_v2_by_id(db, campaign_id)
         if not db_campaign:
             return None
+
+        participations = db.query(CampaignParticipation).filter(CampaignParticipation.campaign_id == campaign_id).all()
+
+        results = {} # Field ID -> {Option -> Count}
+        for p in participations:
+            for field_id, response in p.responses.items():
+                if field_id not in results:
+                    results[field_id] = {}
+
+                resp_str = str(response)
+                results[field_id][resp_str] = results[field_id].get(resp_str, 0) + 1
+
         return {
-            "winners": db_campaign.winners or [],
-            "results_summary": db_campaign.results_summary
+            "campaign_id": campaign_id,
+            "total_participations": len(participations),
+            "responses": results
         }
 
     def update_campaign_image(self, db: Session, campaign_id: int, image_url: str, image_type: str) -> Optional[Campaign]:

--- a/tests/test_campaigns_v2.py
+++ b/tests/test_campaigns_v2.py
@@ -58,8 +58,10 @@ client = TestClient(app)
 def test_list_campaigns():
     response = client.get("/api/campaigns")
     assert response.status_code == 200
-    assert len(response.json()) == 1
-    assert response.json()[0]["title"] == "Predict and Win"
+    data = response.json()
+    assert "items" in data
+    assert len(data["items"]) == 1
+    assert data["items"][0]["title"] == "Predict and Win"
 
 def test_get_active_campaigns():
     response = client.get("/api/campaigns/active")
@@ -100,4 +102,6 @@ def test_get_my_campaign_participation():
 def test_get_results():
     response = client.get("/api/campaigns/camp1/results")
     assert response.status_code == 200
-    assert "winners" in response.json()
+    data = response.json()
+    assert "responses" in data
+    assert "total_participations" in data


### PR DESCRIPTION
Implemented the missing Campaign V2 management APIs according to the provided TypeScript service definition. This includes:
- Administrative listing with pagination, search, and status filters.
- Full CRUD operations and partial updates (PATCH) for campaigns.
- Campaign lifecycle management (Publish/Unpublish).
- Aggregated results statistics providing counts per response for each question.
- Dashboard statistics for total campaigns, active/draft counts, and completion rates.
- CSV and Excel export functionality for campaign participations.
- Generic bulk actions for publishing, unpublishing, deleting, and pausing campaigns.
- Role-based access control ensuring only admins can access management endpoints.

---
*PR created automatically by Jules for task [1666179869185084820](https://jules.google.com/task/1666179869185084820) started by @azeez148*