### PR TITLE
Enrich Campaign Results with Participant Details

### DIFF
--- a/app/schemas/campaign.py
+++ b/app/schemas/campaign.py
@@ -111,10 +111,23 @@ class CampaignParticipationResponse(BaseModel):
         populate_by_name = True
         from_attributes = True
 
+class CampaignParticipantDetailV2(BaseModel):
+    user_id: str = Field(..., alias="userId")
+    name: Optional[str] = None
+    email: Optional[str] = None
+    mobile: Optional[str] = None
+    participation_date: datetime = Field(..., alias="participationDate")
+    responses: Dict[str, Any]
+
+    class Config:
+        populate_by_name = True
+        from_attributes = True
+
 class CampaignResultsV2(BaseModel):
     campaign_id: str = Field(..., alias="campaign_id")
     total_participations: int = Field(..., alias="total_participations")
     responses: Dict[str, Dict[str, int]]
+    participants: Optional[List[CampaignParticipantDetailV2]] = None
     from_date: Optional[str] = Field(None, alias="from")
     to_date: Optional[str] = Field(None, alias="to")
 

--- a/app/services/campaign.py
+++ b/app/services/campaign.py
@@ -604,25 +604,57 @@ class CampaignService:
         ).first()
 
     def get_campaign_results_v2(self, db: Session, campaign_id: str) -> Optional[dict]:
+        from app.models.user import User
+        from app.models.customer import Customer
         db_campaign = self.get_campaign_v2_by_id(db, campaign_id)
         if not db_campaign:
             return None
 
-        participations = db.query(CampaignParticipation).filter(CampaignParticipation.campaign_id == campaign_id).all()
+        query = db.query(
+            CampaignParticipation,
+            User.email.label("user_email"),
+            User.mobile.label("user_mobile"),
+            Customer.first_name,
+            Customer.last_name
+        ).join(
+            User, CampaignParticipation.user_id == User.id
+        ).outerjoin(
+            Customer, User.customer_id == Customer.id
+        ).filter(CampaignParticipation.campaign_id == campaign_id)
+
+        results_data = query.all()
 
         results = {} # Field ID -> {Option -> Count}
-        for p in participations:
-            for field_id, response in p.responses.items():
+        participants_list = []
+
+        for p, user_email, user_mobile, first_name, last_name in results_data:
+            # Aggregate responses
+            for field_id, response in (p.responses or {}).items():
                 if field_id not in results:
                     results[field_id] = {}
 
                 resp_str = str(response)
                 results[field_id][resp_str] = results[field_id].get(resp_str, 0) + 1
 
+            # Formulate participant name
+            user_name = "N/A"
+            if first_name or last_name:
+                user_name = f"{first_name or ''} {last_name or ''}".strip()
+
+            participants_list.append({
+                "userId": p.user_id,
+                "name": user_name,
+                "email": user_email,
+                "mobile": user_mobile,
+                "participationDate": p.participation_date,
+                "responses": p.responses
+            })
+
         return {
             "campaign_id": campaign_id,
-            "total_participations": len(participations),
-            "responses": results
+            "total_participations": len(results_data),
+            "responses": results,
+            "participants": participants_list
         }
 
     def update_campaign_image(self, db: Session, campaign_id: int, image_url: str, image_type: str) -> Optional[Campaign]:


### PR DESCRIPTION
The `get_campaign_results` endpoint in `app/api/campaign_v2.py` has been enhanced to return more comprehensive data. It now includes a `participants` list where each entry contains the user's name (joined from the Customer table), email, mobile number, participation date, and their specific responses to the campaign fields. Aggregated response counts are still maintained.

---
*PR created automatically by Jules for task [6471603221981831811](https://jules.google.com/task/6471603221981831811) started by @azeez148*