### PR TITLE
Optimize /public/all API endpoint performance

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -30,7 +30,7 @@ class Product(BaseModel):
         ProductSize,  # Direct class reference instead of string
         cascade="all, delete-orphan",
         backref="product",
-        lazy="joined"  # This will load the sizes eagerly with the product
+        lazy="selectin"  # Load sizes separately to avoid Cartesian products
     )
     shops = relationship("Shop", secondary="shop_products", back_populates="products")
     tags = relationship("Tag", secondary="product_tags", back_populates="products")

--- a/app/services/home.py
+++ b/app/services/home.py
@@ -1,4 +1,5 @@
 import os
+import time
 from sqlalchemy.orm import Session
 from app.schemas.home import HomeResponse
 from app.services.product import ProductService
@@ -13,26 +14,55 @@ class HomeService:
         self.product_service = ProductService()
         self.event_offer_service = EventOfferService()
 
+    _home_cache = None
+    _last_cache_time = 0
+    CACHE_DURATION = 300  # 5 minutes
+
     def get_home_data(self, db: Session) -> HomeResponse:
+        current_time = time.time()
+
+        # Simple in-memory cache
+        # We store the response as a Pydantic model which is already detached from DB session
+        if self._home_cache and (current_time - self._last_cache_time < self.CACHE_DURATION):
+            return self._home_cache
+
         products = self.product_service.get_all_products(db)
         self._populate_product_images(products)
-        return HomeResponse(products=products)
+
+        # Ensure all nested objects are loaded before creating HomeResponse
+        # HomeResponse(products=products) will trigger Pydantic to read all fields
+        response = HomeResponse.model_validate(HomeResponse(products=products))
+
+        self._home_cache = response
+        self._last_cache_time = current_time
+
+        return response
 
     def _populate_product_images(self, products: List[Product]):
         image_base_path = "images/products"  # base folder path
 
+        # Pre-index the directory to avoid multiple disk I/O calls in a loop
+        image_map = {}
+        if os.path.exists(image_base_path):
+            try:
+                for entry in os.scandir(image_base_path):
+                    if entry.is_dir():
+                        product_id = entry.name
+                        try:
+                            with os.scandir(entry.path) as subentries:
+                                for subentry in subentries:
+                                    if subentry.is_file():
+                                        image_map[product_id] = subentry.name
+                                        break
+                        except OSError:
+                            pass
+            except OSError:
+                pass
+
         for product in products:
             if not product.image_url:
-                # Folder path for this product
-                product_folder = os.path.join(image_base_path, str(product.id))
-
-                # Match any image file inside that folder
-                pattern = os.path.join(product_folder, "*.*")
-                matching_files = glob_module.glob(pattern)
-
-                if matching_files:
-                    # Pick the first file (you can sort or filter if needed)
-                    file_name = os.path.basename(matching_files[0])
+                file_name = image_map.get(str(product.id))
+                if file_name:
                     product.image_url = f"images/products/{product.id}/{file_name}"
                 else:
                     # Fallback to a default image

--- a/app/services/product.py
+++ b/app/services/product.py
@@ -97,7 +97,8 @@ class ProductService:
 
     def get_all_products(self, db: Session) -> List[Product]:
         products = db.query(Product).options(
-            joinedload(Product.shops),
+            joinedload(Product.category),
+            selectinload(Product.shops),
             selectinload(Product.tags)
         ).all()
         return products

--- a/tests/test_product_performance.py
+++ b/tests/test_product_performance.py
@@ -20,17 +20,25 @@ class TestProductEagerLoading(unittest.TestCase):
         query.options.return_value = options_query
         options_query.all.return_value = []
 
-        mock_joinedload.return_value = "shops_loader"
-        mock_selectinload.return_value = "tags_loader"
+        # Side effect to handle multiple calls to joinedload and selectinload
+        def mock_joinedload_side_effect(attr):
+            return f"joined_{attr}"
+        def mock_selectinload_side_effect(attr):
+            return f"selectin_{attr}"
+
+        mock_joinedload.side_effect = mock_joinedload_side_effect
+        mock_selectinload.side_effect = mock_selectinload_side_effect
 
         # Act
         self.product_service.get_all_products(self.db)
 
         # Assert
         self.db.query.assert_called_once_with(Product)
-        query.options.assert_called_once_with("shops_loader", "tags_loader")
-        mock_joinedload.assert_called_once_with(Product.shops)
-        mock_selectinload.assert_called_once_with(Product.tags)
+        query.options.assert_called_once_with(
+            f"joined_{Product.category}",
+            f"selectin_{Product.shops}",
+            f"selectin_{Product.tags}"
+        )
         options_query.all.assert_called_once()
 
 


### PR DESCRIPTION
The `/public/all` endpoint was suffering from several performance bottlenecks that caused response times to exceed 2.5 seconds. 

Key improvements:
1. **Filesystem Optimization**: The `_populate_product_images` method previously called `glob.glob` for every product in a loop. For a large catalog, this resulted in hundreds of redundant directory scans. This has been replaced with a single pre-indexing pass using `os.scandir`, reducing the complexity from O(N*M) to roughly O(N+M) where N is the number of products and M is the number of images.
2. **Database Query Optimization**: Switched from `joinedload` to `selectinload` for the `shops` and `tags` relationships in `ProductService.get_all_products`. Additionally, changed the `size_map` relationship in the `Product` model to `lazy="selectin"`. These changes prevent the "Cartesian product" problem where SQLAlchemy generates massive result sets when multiple collections are joined, significantly reducing query time and memory usage.
3. **Caching**: Introduced a simple in-memory cache in `HomeService` with a 5-minute TTL. The cache stores validated Pydantic models to ensure data is detached from the SQLAlchemy session, preventing potential `DetachedInstanceError` while providing near-instant responses for repeat visitors.

These changes collectively address the reported slowness and provide a more scalable architecture for the public-facing API.

---
*PR created automatically by Jules for task [9507699633330054268](https://jules.google.com/task/9507699633330054268) started by @azeez148*