### PR TITLE
Migrate Image Storage to Cloudflare R2

### DIFF
--- a/app/api/campaign_v2.py
+++ b/app/api/campaign_v2.py
@@ -15,6 +15,7 @@ from app.schemas.campaign import (
     CampaignStatsV2, BulkActionRequestV2, BulkActionResponseV2
 )
 from app.services.campaign import CampaignService
+from app.services.storage import StorageService
 from app.api.auth import get_current_user_admin
 import pandas as pd
 import tempfile
@@ -24,6 +25,7 @@ from starlette.background import BackgroundTask
 
 router = APIRouter()
 campaign_service = CampaignService()
+storage_service = StorageService()
 
 @router.get("", response_model=CampaignListResponseV2)
 async def list_campaigns(
@@ -245,36 +247,19 @@ async def upload_campaign_image(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user_admin)
 ):
-    # Define the directory to store the image
-    upload_dir = Path(f"images/campaigns/{id}")
-    os.makedirs(upload_dir, exist_ok=True)
+    # Get existing campaign to check for old image
+    campaign = campaign_service.get_campaign_v2_by_id(db, id)
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Campaign not found")
 
-    # Delete any existing files in the directory to keep it clean
-    for existing_file in upload_dir.iterdir():
-        if existing_file.is_file():
-            existing_file.unlink()
+    # Delete old image from R2 if it exists
+    if campaign.image_url and campaign.image_url.startswith("http"):
+        await storage_service.delete_image(campaign.image_url)
 
-    # Get sanitized original filename or use a default
-    original_filename = os.path.basename(image.filename)
-    file_ext = Path(original_filename).suffix
-    if not file_ext:
-        file_ext = ".jpg" # Default extension if none found
-
-    new_filename = f"image{file_ext}"
-    file_path = upload_dir / new_filename
-
-    # Save the file
-    with open(file_path, "wb") as buffer:
-        shutil.copyfileobj(image.file, buffer)
+    # Upload new image to R2
+    image_url = await storage_service.upload_image(image, folder="campaigns")
 
     # Update the campaign's image_url in the database
-    image_url = str(file_path).replace("\\", "/")
     updated_campaign = campaign_service.update_campaign_v2_image(db, id, image_url)
-
-    if not updated_campaign:
-        # Cleanup file if campaign not found
-        if file_path.exists():
-            file_path.unlink()
-        raise HTTPException(status_code=404, detail="Campaign not found")
 
     return updated_campaign

--- a/app/api/products.py
+++ b/app/api/products.py
@@ -27,9 +27,11 @@ from app.schemas.stock import ClearStockRequest, StockResponse
 from app.services.product import ProductService
 from app.services.category import CategoryService
 from app.services.stock import StockService
+from app.services.storage import StorageService
 
 router = APIRouter()
 product_service = ProductService()
+storage_service = StorageService()
 category_service = CategoryService()
 
 @router.post("/addProduct", response_model=ProductResponse)
@@ -162,31 +164,21 @@ async def upload_product_images(
     image: UploadFile = File(...),
     db: Session = Depends(get_db)
 ):
-    # Define the directory to store the image
-    upload_dir = Path(f"images/products/{product_id}")
-    os.makedirs(upload_dir, exist_ok=True)
-
-    # Delete any existing files in the directory
-    for existing_file in upload_dir.iterdir():
-        if existing_file.is_file():
-            existing_file.unlink()
-
-    # Rename the uploaded file to product_id with its original extension
-    file_ext = Path(image.filename).suffix
-    new_filename = f"{product_id}{file_ext}"
-    file_path = upload_dir / new_filename
-
-    # Save the file
-    with open(file_path, "wb") as buffer:
-        shutil.copyfileobj(image.file, buffer)
-
-    # Update the product's image_url in the database
-    image_url = str(file_path).replace("\\", "/")
-    updated_product = product_service.update_product_image_url(db, product_id, image_url)
-
-    if not updated_product:
+    # Get existing product to check for old image
+    product = product_service.get_product_by_id(db, product_id)
+    if not product:
         logger.error(f"Product with id {product_id} not found")
         raise HTTPException(status_code=404, detail="Product not found")
+
+    # Delete old image from R2 if it exists
+    if product.image_url and product.image_url.startswith("http"):
+        await storage_service.delete_image(product.image_url)
+
+    # Upload new image to R2
+    image_url = await storage_service.upload_image(image, folder="products")
+
+    # Update the product's image_url in the database
+    updated_product = product_service.update_product_image_url(db, product_id, image_url)
 
     return updated_product
 

--- a/app/api/storage.py
+++ b/app/api/storage.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, UploadFile, File, HTTPException, Depends, Query
+from app.services.storage import StorageService
+from app.api.auth import get_current_user_admin
+from pydantic import BaseModel
+
+router = APIRouter()
+storage_service = StorageService()
+
+@router.post("/upload-image")
+async def upload_image(
+    file: UploadFile = File(...),
+    folder: str = "products",
+    current_user = Depends(get_current_user_admin)
+):
+    """
+    Upload an image to Cloudflare R2.
+    """
+    url = await storage_service.upload_image(file, folder)
+    return {"url": url}
+
+@router.delete("/upload-image")
+async def delete_image(
+    file_url: str = Query(...),
+    current_user = Depends(get_current_user_admin)
+):
+    """
+    Delete an image from Cloudflare R2.
+    """
+    await storage_service.delete_image(file_url)
+    return {"message": "Image deletion requested"}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -24,6 +24,13 @@ class Settings(BaseSettings):
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # 7 days
 
+    # Cloudflare R2 Settings
+    R2_ACCOUNT_ID: Optional[str] = os.getenv("R2_ACCOUNT_ID")
+    R2_ACCESS_KEY_ID: Optional[str] = os.getenv("R2_ACCESS_KEY_ID")
+    R2_SECRET_ACCESS_KEY: Optional[str] = os.getenv("R2_SECRET_ACCESS_KEY")
+    R2_BUCKET_NAME: str = os.getenv("R2_BUCKET_NAME", "ssms-images")
+    R2_PUBLIC_URL: str = os.getenv("R2_PUBLIC_URL", "")
+
 
     class Config:
         env_file = ".env"

--- a/app/main.py
+++ b/app/main.py
@@ -79,7 +79,8 @@ from app.api import (
     pricelist,
     report,
     campaigns,
-    campaign_v2
+    campaign_v2,
+    storage
 )
 
 # Include all routers
@@ -106,6 +107,7 @@ app.include_router(users.router, prefix="/users", tags=["users"])
 app.include_router(pricelist.router, prefix="/pricelists", tags=["pricelists"])
 app.include_router(campaign_v2.router, prefix="/campaigns", tags=["campaigns-v2"])
 app.include_router(campaign_v2.router, prefix="/api/campaigns", tags=["campaigns-v2"])
+app.include_router(storage.router, prefix="/storage", tags=["storage"])
 
 
 @app.get("/")

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -1,0 +1,104 @@
+import boto3
+import uuid
+import magic
+import os
+from botocore.config import Config
+from fastapi import UploadFile, HTTPException
+from starlette.concurrency import run_in_threadpool
+from typing import Optional, List
+from app.core.config import settings
+from app.core.logging import logger
+
+class StorageService:
+    def __init__(self):
+        self.s3_client = None
+        if all([settings.R2_ACCOUNT_ID, settings.R2_ACCESS_KEY_ID, settings.R2_SECRET_ACCESS_KEY]):
+            self.s3_client = boto3.client(
+                service_name="s3",
+                endpoint_url=f"https://{settings.R2_ACCOUNT_ID}.r2.cloudflarestorage.com",
+                aws_access_key_id=settings.R2_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.R2_SECRET_ACCESS_KEY,
+                config=Config(signature_version="s3v4"),
+                region_name="auto"
+            )
+        else:
+            logger.warning("Cloudflare R2 credentials not fully configured. StorageService might not work correctly.")
+
+        self.bucket_name = settings.R2_BUCKET_NAME
+        self.public_url = settings.R2_PUBLIC_URL.rstrip("/")
+        self.allowed_content_types = ["image/jpeg", "image/png", "image/webp"]
+        self.max_file_size = 5 * 1024 * 1024  # 5MB
+
+    def generate_unique_filename(self, original_filename: str) -> str:
+        ext = os.path.splitext(original_filename)[1].lower()
+        return f"{uuid.uuid4()}{ext}"
+
+    def _get_content_type(self, content: bytes) -> str:
+        return magic.from_buffer(content, mime=True)
+
+    def _put_object(self, object_key: str, content: bytes, content_type: str):
+        self.s3_client.put_object(
+            Bucket=self.bucket_name,
+            Key=object_key,
+            Body=content,
+            ContentType=content_type
+        )
+
+    def _delete_object(self, object_key: str):
+        self.s3_client.delete_object(
+            Bucket=self.bucket_name,
+            Key=object_key
+        )
+
+    async def upload_image(self, file: UploadFile, folder: str = "products") -> str:
+        if not self.s3_client:
+            raise HTTPException(status_code=500, detail="Storage service not configured")
+
+        # Read file content
+        content = await file.read()
+        file_size = len(content)
+
+        # Validate file size
+        if file_size > self.max_file_size:
+            raise HTTPException(status_code=400, detail=f"File size exceeds limit of {self.max_file_size // (1024*1024)}MB")
+
+        # Validate content type (running in threadpool as magic can be slow)
+        content_type = await run_in_threadpool(self._get_content_type, content)
+        if content_type not in self.allowed_content_types:
+            raise HTTPException(status_code=400, detail=f"Unsupported file type: {content_type}. Allowed: {', '.join(self.allowed_content_types)}")
+
+        # Generate unique filename
+        filename = self.generate_unique_filename(file.filename)
+        object_key = f"{folder}/{filename}"
+
+        try:
+            # Upload to R2 (running in threadpool as boto3 is blocking)
+            await run_in_threadpool(self._put_object, object_key, content, content_type)
+
+            # Construct public URL
+            if self.public_url:
+                return f"{self.public_url}/{object_key}"
+            else:
+                return f"https://{self.bucket_name}.{settings.R2_ACCOUNT_ID}.r2.cloudflarestorage.com/{object_key}"
+
+        except Exception as e:
+            logger.error(f"Error uploading image to R2: {str(e)}")
+            raise HTTPException(status_code=500, detail=f"Could not upload image: {str(e)}")
+
+    async def delete_image(self, file_url: str):
+        if not self.s3_client:
+            logger.warning("Storage service not configured, skipping deletion.")
+            return
+
+        try:
+            # Extract object key from URL
+            if self.public_url and file_url.startswith(self.public_url):
+                object_key = file_url.replace(f"{self.public_url}/", "")
+            else:
+                parts = file_url.split("/")
+                object_key = "/".join(parts[-2:])
+
+            await run_in_threadpool(self._delete_object, object_key)
+            logger.info(f"Deleted image from R2: {object_key}")
+        except Exception as e:
+            logger.error(f"Error deleting image from R2: {str(e)}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ numpy==1.26.4
 openpyxl==3.1.2
 pydantic-settings
 pytest
+boto3==1.28.62
+python-magic==0.4.27

--- a/scripts/migrate_to_r2.py
+++ b/scripts/migrate_to_r2.py
@@ -7,41 +7,54 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from sqlalchemy.orm import Session
 from app.core.database import SessionLocal
 from app.models.product import Product
+from app.models.campaign import CampaignV2
 from app.core.config import settings
 
-def migrate_product_urls():
+def migrate_product_urls(db: Session, r2_base_url: str):
+    products = db.query(Product).filter(Product.image_url.like("images/products/%")).all()
+    print(f"Found {len(products)} products with local image paths.")
+
+    updated_count = 0
+    for product in products:
+        old_url = product.image_url
+        # Remove 'images/' prefix
+        new_path = old_url.replace("images/", "", 1)
+        new_url = f"{r2_base_url}/{new_path}"
+
+        print(f"Updating product {product.id}: {old_url} -> {new_url}")
+        product.image_url = new_url
+        updated_count += 1
+    return updated_count
+
+def migrate_campaign_urls(db: Session, r2_base_url: str):
+    campaigns = db.query(CampaignV2).filter(CampaignV2.image_url.like("images/campaigns/%")).all()
+    print(f"Found {len(campaigns)} campaigns with local image paths.")
+
+    updated_count = 0
+    for campaign in campaigns:
+        old_url = campaign.image_url
+        # Remove 'images/' prefix
+        new_path = old_url.replace("images/", "", 1)
+        new_url = f"{r2_base_url}/{new_path}"
+
+        print(f"Updating campaign {campaign.id}: {old_url} -> {new_url}")
+        campaign.image_url = new_url
+        updated_count += 1
+    return updated_count
+
+def main():
+    if not settings.R2_PUBLIC_URL:
+        print("Error: R2_PUBLIC_URL is not set in environment variables.")
+        return
+
+    r2_base_url = settings.R2_PUBLIC_URL.rstrip("/")
     db: Session = SessionLocal()
     try:
-        products = db.query(Product).filter(Product.image_url.like("images/products/%")).all()
-        print(f"Found {len(products)} products with local image paths.")
-
-        if not settings.R2_PUBLIC_URL:
-            print("Error: R2_PUBLIC_URL is not set in environment variables.")
-            return
-
-        r2_base_url = settings.R2_PUBLIC_URL.rstrip("/")
-
-        updated_count = 0
-        for product in products:
-            # Local path format: images/products/{id}/{filename}
-            # We want to change it to: {r2_base_url}/products/{filename}
-            # or keep the structure: {r2_base_url}/products/{id}/{filename}
-
-            # The current implementation of StorageService uploads to {folder}/{unique_filename}
-            # If the user manually moves files, they might want to keep the structure or change it.
-            # Assuming they move 'images/products/*' to 'products/*' in R2.
-
-            old_url = product.image_url
-            # Remove 'images/' prefix
-            new_path = old_url.replace("images/", "", 1)
-            new_url = f"{r2_base_url}/{new_path}"
-
-            print(f"Updating product {product.id}: {old_url} -> {new_url}")
-            product.image_url = new_url
-            updated_count += 1
+        product_updated = migrate_product_urls(db, r2_base_url)
+        campaign_updated = migrate_campaign_urls(db, r2_base_url)
 
         db.commit()
-        print(f"Successfully updated {updated_count} product image URLs.")
+        print(f"Successfully updated {product_updated} product URLs and {campaign_updated} campaign URLs.")
 
     except Exception as e:
         db.rollback()
@@ -50,4 +63,4 @@ def migrate_product_urls():
         db.close()
 
 if __name__ == "__main__":
-    migrate_product_urls()
+    main()

--- a/scripts/migrate_to_r2.py
+++ b/scripts/migrate_to_r2.py
@@ -1,0 +1,53 @@
+import sys
+import os
+
+# Add the project root to the python path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy.orm import Session
+from app.core.database import SessionLocal
+from app.models.product import Product
+from app.core.config import settings
+
+def migrate_product_urls():
+    db: Session = SessionLocal()
+    try:
+        products = db.query(Product).filter(Product.image_url.like("images/products/%")).all()
+        print(f"Found {len(products)} products with local image paths.")
+
+        if not settings.R2_PUBLIC_URL:
+            print("Error: R2_PUBLIC_URL is not set in environment variables.")
+            return
+
+        r2_base_url = settings.R2_PUBLIC_URL.rstrip("/")
+
+        updated_count = 0
+        for product in products:
+            # Local path format: images/products/{id}/{filename}
+            # We want to change it to: {r2_base_url}/products/{filename}
+            # or keep the structure: {r2_base_url}/products/{id}/{filename}
+
+            # The current implementation of StorageService uploads to {folder}/{unique_filename}
+            # If the user manually moves files, they might want to keep the structure or change it.
+            # Assuming they move 'images/products/*' to 'products/*' in R2.
+
+            old_url = product.image_url
+            # Remove 'images/' prefix
+            new_path = old_url.replace("images/", "", 1)
+            new_url = f"{r2_base_url}/{new_path}"
+
+            print(f"Updating product {product.id}: {old_url} -> {new_url}")
+            product.image_url = new_url
+            updated_count += 1
+
+        db.commit()
+        print(f"Successfully updated {updated_count} product image URLs.")
+
+    except Exception as e:
+        db.rollback()
+        print(f"Error during migration: {e}")
+    finally:
+        db.close()
+
+if __name__ == "__main__":
+    migrate_product_urls()

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -1,0 +1,76 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import UploadFile
+from app.services.storage import StorageService
+import io
+
+@pytest.fixture
+def storage_service():
+    with patch('boto3.client'):
+        # Mock settings to have required R2 credentials
+        with patch('app.services.storage.settings') as mock_settings:
+            mock_settings.R2_ACCOUNT_ID = "test-account"
+            mock_settings.R2_ACCESS_KEY_ID = "test-key"
+            mock_settings.R2_SECRET_ACCESS_KEY = "test-secret"
+            mock_settings.R2_BUCKET_NAME = "test-bucket"
+            mock_settings.R2_PUBLIC_URL = "https://cdn.example.com"
+            yield StorageService()
+
+@pytest.mark.asyncio
+async def test_generate_unique_filename(storage_service):
+    filename = "test.jpg"
+    unique_name = storage_service.generate_unique_filename(filename)
+    assert unique_name.endswith(".jpg")
+    assert len(unique_name) > 10
+
+@pytest.mark.asyncio
+@patch('app.services.storage.run_in_threadpool')
+async def test_upload_image_success(mock_run, storage_service):
+    # Mock content type check and put_object
+    async def side_effect(func, *args, **kwargs):
+        if func == storage_service._get_content_type:
+            return "image/jpeg"
+        return None
+
+    mock_run.side_effect = side_effect
+
+    # Mock UploadFile
+    content = b"fake image content"
+    file = MagicMock(spec=UploadFile)
+    file.filename = "test.jpg"
+    file.read.return_value = content
+
+    url = await storage_service.upload_image(file)
+
+    assert url.startswith("https://cdn.example.com/products/")
+    assert url.endswith(".jpg")
+    assert mock_run.call_count == 2 # 1 for content type, 1 for put_object
+
+@pytest.mark.asyncio
+@patch('app.services.storage.run_in_threadpool')
+async def test_upload_image_invalid_type(mock_run, storage_service):
+    mock_run.return_value = "application/pdf"
+
+    file = MagicMock(spec=UploadFile)
+    file.filename = "test.pdf"
+    file.read.return_value = b"fake pdf content"
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as excinfo:
+        await storage_service.upload_image(file)
+
+    assert excinfo.value.status_code == 400
+    assert "Unsupported file type" in excinfo.value.detail
+
+@pytest.mark.asyncio
+@patch('app.services.storage.run_in_threadpool')
+async def test_delete_image(mock_run, storage_service):
+    file_url = "https://cdn.example.com/products/test-uuid.jpg"
+
+    await storage_service.delete_image(file_url)
+
+    mock_run.assert_called_once()
+    func_called = mock_run.call_args[0][0]
+    args_called = mock_run.call_args[0][1:]
+    assert func_called == storage_service._delete_object
+    assert args_called == ("products/test-uuid.jpg",)


### PR DESCRIPTION
This change migrates the application's image storage from the local VPS filesystem to Cloudflare R2. 

Key components:
1. **StorageService (`app/services/storage.py`)**: A clean service layer that handles communication with R2. It uses `boto3` and ensures the event loop is not blocked by wrapping synchronous calls in `run_in_threadpool`. It includes file size and content-type validation using `python-magic`.
2. **API Endpoints (`app/api/storage.py`)**: Provides `POST /storage/upload-image` and `DELETE /storage/upload-image` for administrative image management.
3. **Migration Script (`scripts/migrate_to_r2.py`)**: A utility to update existing database records from local paths (e.g., `images/products/...`) to R2 CDN URLs.
4. **Configuration**: Added support for `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`, and `R2_PUBLIC_URL` in `app/core/config.py`.

Testing:
- Unit tests added in `tests/test_storage_service.py` and verified to pass.
- Content-type validation and size restrictions were verified.

---
*PR created automatically by Jules for task [590854933762164310](https://jules.google.com/task/590854933762164310) started by @azeez148*