### PR TITLE
Add size_map to home API and optimize performance

### DIFF
--- a/app/api/home.py
+++ b/app/api/home.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from app.core.database import get_db
 from app.schemas.home import HomeResponse, OfferResponse
-from app.schemas.product import ProductMinimalListResponse, ProductResponse
+from app.schemas.product import ProductHomeMinimalListResponse, ProductMinimalListResponse, ProductResponse
 from app.schemas.category import CategoryResponse
 from app.schemas.sale import SaleCreate, SaleResponse
 from app.schemas.stock import StockRequest, StockResponse
@@ -26,7 +26,7 @@ tag_service = TagService()
 async def get_home_data(db: Session = Depends(get_db)):
     return home_service.get_home_data(db)
 
-@router.get("/products", response_model=ProductMinimalListResponse)
+@router.get("/products", response_model=ProductHomeMinimalListResponse)
 async def get_products(db: Session = Depends(get_db), skip: int = 0,
     limit: Optional[int] = 50,
     category_id: Optional[int] = None,
@@ -67,7 +67,7 @@ async def get_weekly_offers(db: Session = Depends(get_db)):
 async def get_categories(db: Session = Depends(get_db)):
     return home_service.get_categories(db)
 
-@router.get("/search", response_model=ProductMinimalListResponse)
+@router.get("/search", response_model=ProductHomeMinimalListResponse)
 async def search_products(search: str, db: Session = Depends(get_db), skip: int = 0,
     limit: Optional[int] = 50,
     category_id: Optional[int] = None,

--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -108,6 +108,15 @@ class ProductMinimalListResponse(BaseModel):
     page: int
     per_page: int
 
+class ProductHomeMinimalResponse(ProductMinimalResponse):
+    size_map: Optional[List[ProductSizeBase]] = None
+
+class ProductHomeMinimalListResponse(BaseModel):
+    items: List[ProductHomeMinimalResponse]
+    total: int
+    page: int
+    per_page: int
+
 class UpdateSizeMapRequest(BaseModel):
     product_id: int
     size_map: Dict[str, int]

--- a/app/services/home.py
+++ b/app/services/home.py
@@ -75,7 +75,15 @@ class HomeService:
         return self.event_offer_service.get_active_event_offers(db)
 
     def get_weekly_offers(self, db: Session) -> List[Product]:
-        offer = self.event_offer_service.get_event_offer_by_code(db, "WEEKLY50OFF")
+        offer = db.query(EventOffer).options(
+            selectinload(EventOffer.products).options(
+                joinedload(Product.category),
+                selectinload(Product.shops),
+                selectinload(Product.tags),
+                selectinload(Product.size_map)
+            )
+        ).filter(EventOffer.code == "WEEKLY50OFF").first()
+
         if not offer:
             return []
 
@@ -91,10 +99,20 @@ class HomeService:
     #     return products
 
     def get_new_arrivals(self, db: Session) -> List[Product]:
-        return db.query(Product).order_by(Product.created_date.desc()).limit(20).all()
+        return db.query(Product).options(
+            joinedload(Product.category),
+            selectinload(Product.shops),
+            selectinload(Product.tags),
+            selectinload(Product.size_map)
+        ).order_by(Product.created_date.desc()).limit(20).all()
 
     def get_offer_products(self, db: Session) -> List[Product]:
-        return db.query(Product).filter(Product.offer_id.isnot(None)).all()
+        return db.query(Product).options(
+            joinedload(Product.category),
+            selectinload(Product.shops),
+            selectinload(Product.tags),
+            selectinload(Product.size_map)
+        ).filter(Product.offer_id.isnot(None)).all()
 
     def get_product_by_id(self, db: Session, product_id: int) -> Optional[Product]:
         return self.product_service.get_product_by_id(db, product_id)

--- a/app/services/product.py
+++ b/app/services/product.py
@@ -174,7 +174,8 @@ class ProductService:
         query = query.options(
             joinedload(Product.category),
             selectinload(Product.shops),
-            selectinload(Product.tags)
+            selectinload(Product.tags),
+            selectinload(Product.size_map)
         )
 
         # Always apply offset/limit to ensure consistent query building for tests

--- a/tests/test_home_api_size_map.py
+++ b/tests/test_home_api_size_map.py
@@ -1,0 +1,67 @@
+import unittest
+from unittest.mock import MagicMock
+from app.services.product import ProductService
+from app.schemas.product import ProductHomeMinimalResponse
+
+class TestHomeApiSizeMap(unittest.TestCase):
+    def setUp(self):
+        self.product_service = ProductService()
+        self.db = MagicMock()
+
+    def test_get_all_products_minimal_with_size_map(self):
+        # Setup mock product with size map
+        mock_product = MagicMock()
+        mock_product.id = 1
+        mock_product.name = "Test Product"
+        mock_product.description = "Test Description"
+        mock_product.unit_price = 100
+        mock_product.selling_price = 150
+        mock_product.category_id = 1
+        mock_product.is_active = True
+        mock_product.can_listed = True
+        mock_product.image_url = "http://example.com/image.jpg"
+        mock_product.is_duplicate = False
+        mock_product.parent_product_id = None
+        mock_product.discounted_price = 120
+        mock_product.category.name = "Test Category"
+        mock_product.shops = []
+        mock_product.offer_id = None
+
+        mock_size = MagicMock()
+        mock_size.size = "M"
+        mock_size.quantity = 10
+        mock_product.size_map = [mock_size]
+
+        # Mock the query results
+        query = MagicMock()
+        self.db.query.return_value = query
+
+        order_query = MagicMock()
+        query.order_by.return_value = order_query
+        order_query.count.return_value = 1
+
+        options_query = MagicMock()
+        order_query.options.return_value = options_query
+
+        offset_query = MagicMock()
+        options_query.offset.return_value = offset_query
+
+        offset_query.all.return_value = [mock_product]
+
+        # Act
+        products, total = self.product_service.get_all_products_minimal(self.db)
+
+        # Assert
+        self.assertEqual(len(products), 1)
+        product = products[0]
+
+        # Verify schema validation
+        response_schema = ProductHomeMinimalResponse.model_validate(product)
+        self.assertIsNotNone(response_schema.size_map)
+        self.assertEqual(len(response_schema.size_map), 1)
+        self.assertEqual(response_schema.size_map[0].size, "M")
+        self.assertEqual(response_schema.size_map[0].quantity, 10)
+        self.assertTrue(response_schema.is_in_stock)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The home API endpoints `get_products` and `search_products` were missing `size_map` data in their responses. This task involved adding the `size_map` field to these endpoints while ensuring high performance.

Key changes:
1.  **Schema Updates**: Introduced `ProductHomeMinimalResponse` and `ProductHomeMinimalListResponse` in `app/schemas/product.py` to include the `size_map` field without breaking existing `ProductMinimalResponse` usage elsewhere.
2.  **API Updates**: Modified `app/api/home.py` to use the new schemas for `get_products` and `search_products`.
3.  **Performance Optimization**: 
    - Updated `ProductService.get_all_products` in `app/services/product.py` to use `selectinload(Product.size_map)`, ensuring efficient fetching of sizes in a single batch.
    - Updated `HomeService` methods in `app/services/home.py` (`get_new_arrivals`, `get_offer_products`, `get_weekly_offers`) to use eager loading (`joinedload` and `selectinload`) for `category`, `shops`, `tags`, and `size_map`.
4.  **Verification**: Created a new test `tests/test_home_api_size_map.py` to verify that the schema correctly includes `size_map` and ran existing optimization tests to ensure no regressions.

---
*PR created automatically by Jules for task [17431327218366125401](https://jules.google.com/task/17431327218366125401) started by @azeez148*