### PR TITLE
Update Dashboard API Metrics and Filtering

### DIFF
--- a/app/api/dashboard.py
+++ b/app/api/dashboard.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
+from typing import Optional
 
 from app.core.database import get_db
 from app.services.dashboard import DashboardService
@@ -9,5 +10,8 @@ router = APIRouter()
 dashboard_service = DashboardService()
 
 @router.get("/all", response_model=Dashboard)
-async def get_dashboard_data(db: Session = Depends(get_db)):
-    return dashboard_service.get_dashboard_data(db)
+async def get_dashboard_data(
+    shop_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db)
+):
+    return dashboard_service.get_dashboard_data(db, shop_id=shop_id)

--- a/app/api/products.py
+++ b/app/api/products.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File
 from httpcore import request
 from sqlalchemy.orm import Session
 from typing import List, Optional

--- a/app/schemas/dashboard.py
+++ b/app/schemas/dashboard.py
@@ -1,17 +1,42 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Dict, List
 from app.schemas.sale import SaleResponse
 from app.schemas.purchase import PurchaseResponse
 from app.schemas.base import BaseSchema
 
+class SalesSummary(BaseModel):
+    total_count: int
+    total_revenue: float
+    total_items_sold: int
+
+class PurchasesSummary(BaseModel):
+    total_count: int
+    total_cost: float
+    total_items_purchased: int
+
+class InventorySummary(BaseModel):
+    total_stock_value: float
+    projected_sale_value: float
+    projected_profit_value: float
+
+class MostSoldItem(BaseModel):
+    product_name: str
+    product_category: str
+    total_quantity: int
+    total_revenue: float
+
 class Dashboard(BaseSchema):
-    total_sales: Dict
+    total_sales: SalesSummary
+    todays_sales: SalesSummary
+    pending_sales: SalesSummary
+    shipped_sales: SalesSummary
+    total_purchases: PurchasesSummary
+    todays_purchases: PurchasesSummary
     total_products: int
     total_categories: int
-    most_sold_items: Dict
+    inventory_summary: InventorySummary
+    most_sold_items: Dict[str, MostSoldItem]
     recent_sales: List[SaleResponse]
-    total_purchases: Dict
     recent_purchases: List[PurchaseResponse]
     
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/app/services/dashboard.py
+++ b/app/services/dashboard.py
@@ -1,26 +1,128 @@
-from sqlalchemy import func
-from sqlalchemy.orm import Session
-from typing import Dict
+from sqlalchemy import func, and_
+from sqlalchemy.orm import Session, joinedload
+from typing import Dict, List, Optional
+from datetime import datetime
 from app.models.category import Category
 from app.models.product import Product
-from app.services.sale import SaleService
-from app.services.purchase import PurchaseService
+from app.models.product_size import ProductSize
+from app.models.sale import Sale, SaleItem
+from app.models.purchase import Purchase, PurchaseItem, shop_purchases
+from app.schemas.enums import SaleStatus
 
 class DashboardService:
-    def __init__(self):
-        self.sale_service = SaleService()
-        self.purchase_service = PurchaseService()
+    def get_dashboard_data(self, db: Session, shop_id: Optional[int] = None) -> Dict:
+        today = datetime.utcnow().date().isoformat()
 
-    def get_dashboard_data(self, db: Session) -> Dict:
-        total_products = db.query(func.count(Product.id)).scalar() or 0
+        # Sales Calculations
+        def get_sales_summary(filters):
+            query = db.query(
+                func.count(Sale.id),
+                func.coalesce(func.sum(Sale.total_price), 0.0),
+                func.coalesce(func.sum(Sale.total_quantity), 0)
+            ).filter(*filters)
+            if shop_id:
+                query = query.filter(Sale.shop_id == shop_id)
+            res = query.one()
+            return {
+                "total_count": int(res[0] or 0),
+                "total_revenue": float(res[1] or 0.0),
+                "total_items_sold": int(res[2] or 0)
+            }
+
+        total_sales = get_sales_summary([Sale.status.in_([SaleStatus.COMPLETED, SaleStatus.SHIPPED])])
+        todays_sales = get_sales_summary([Sale.date == today, Sale.status != SaleStatus.CANCELLED])
+        pending_sales = get_sales_summary([Sale.date == today, Sale.status == SaleStatus.PENDING])
+        shipped_sales = get_sales_summary([Sale.date == today, Sale.status == SaleStatus.SHIPPED])
+
+        # Purchase Calculations
+        def get_purchases_summary(filters):
+            query = db.query(
+                func.count(Purchase.id),
+                func.coalesce(func.sum(Purchase.total_price), 0.0),
+                func.coalesce(func.sum(Purchase.total_quantity), 0)
+            ).filter(*filters)
+            if shop_id:
+                query = query.join(shop_purchases, Purchase.id == shop_purchases.c.purchase_id).filter(shop_purchases.c.shop_id == shop_id)
+            res = query.one()
+            return {
+                "total_count": int(res[0] or 0),
+                "total_cost": float(res[1] or 0.0),
+                "total_items_purchased": int(res[2] or 0)
+            }
+
+        total_purchases = get_purchases_summary([])
+        todays_purchases = get_purchases_summary([Purchase.date == today])
+
+        # Product and Category Counts
+        prod_query = db.query(func.count(Product.id))
+        if shop_id:
+            prod_query = prod_query.join(Product.shops).filter(Product.shops.any(id=shop_id))
+        total_products = prod_query.scalar() or 0
         total_categories = db.query(func.count(Category.id)).scalar() or 0
 
+        # Inventory Summary
+        inventory_query = db.query(
+            func.coalesce(func.sum(ProductSize.quantity * Product.unit_price), 0.0),
+            func.coalesce(func.sum(ProductSize.quantity * Product.selling_price), 0.0)
+        ).select_from(Product).join(ProductSize, Product.id == ProductSize.product_id)
+        if shop_id:
+            inventory_query = inventory_query.filter(Product.shops.any(id=shop_id))
+
+        inv_res = inventory_query.one()
+        total_stock_value = float(inv_res[0] or 0.0)
+        projected_sale_value = float(inv_res[1] or 0.0)
+        projected_profit_value = projected_sale_value - total_stock_value
+
+        # Most Sold Items
+        most_sold_query = db.query(
+            SaleItem.product_id,
+            SaleItem.product_name,
+            SaleItem.product_category,
+            func.coalesce(func.sum(SaleItem.quantity), 0).label("total_quantity"),
+            func.coalesce(func.sum(SaleItem.total_price), 0.0).label("total_revenue")
+        ).join(Sale, SaleItem.sale_id == Sale.id).group_by(SaleItem.product_id, SaleItem.product_name, SaleItem.product_category)
+
+        if shop_id:
+            most_sold_query = most_sold_query.filter(Sale.shop_id == shop_id)
+
+        most_sold_res = most_sold_query.order_by(func.sum(SaleItem.quantity).desc()).limit(5).all()
+
+        most_sold_items = {
+            f"item_{r.product_id}": {
+                "product_name": r.product_name,
+                "product_category": r.product_category,
+                "total_quantity": int(r.total_quantity),
+                "total_revenue": float(r.total_revenue)
+            } for r in most_sold_res
+        }
+
+        # Recent Sales
+        recent_sales_query = db.query(Sale).options(joinedload(Sale.customer))
+        if shop_id:
+            recent_sales_query = recent_sales_query.filter(Sale.shop_id == shop_id)
+        recent_sales = recent_sales_query.order_by(Sale.date.desc(), Sale.id.desc()).limit(5).all()
+
+        # Recent Purchases
+        recent_purchases_query = db.query(Purchase).options(joinedload(Purchase.vendor))
+        if shop_id:
+            recent_purchases_query = recent_purchases_query.join(shop_purchases, Purchase.id == shop_purchases.c.purchase_id).filter(shop_purchases.c.shop_id == shop_id)
+        recent_purchases = recent_purchases_query.order_by(Purchase.date.desc(), Purchase.id.desc()).limit(5).all()
+
         return {
-            "total_sales": self.sale_service.get_total_sales(db),
+            "total_sales": total_sales,
+            "todays_sales": todays_sales,
+            "pending_sales": pending_sales,
+            "shipped_sales": shipped_sales,
+            "total_purchases": total_purchases,
+            "todays_purchases": todays_purchases,
             "total_products": int(total_products),
             "total_categories": int(total_categories),
-            "most_sold_items": self.sale_service.get_most_sold_items(db),
-            "recent_sales": self.sale_service.get_recent_sales(db),
-            "total_purchases": self.purchase_service.get_total_purchases(db),
-            "recent_purchases": self.purchase_service.get_recent_purchases(db)
+            "inventory_summary": {
+                "total_stock_value": total_stock_value,
+                "projected_sale_value": projected_sale_value,
+                "projected_profit_value": projected_profit_value
+            },
+            "most_sold_items": most_sold_items,
+            "recent_sales": recent_sales,
+            "recent_purchases": recent_purchases
         }


### PR DESCRIPTION
The dashboard API has been updated to provide a more comprehensive overview of business performance. Key changes include:
- Support for an optional `shop_id` query parameter to filter all metrics by shop.
- Detailed sales breakdown: total (completed/shipped), today's total (non-cancelled), today's pending, and today's shipped.
- Detailed purchase breakdown: total and today's.
- Inventory summary: total stock value (at cost), projected sale value (at selling price), and projected profit.
- Top 5 most sold items, recent 5 sales, and recent 5 purchases.
- All response structures have been updated to match the requested JSON format using Pydantic V2.

---
*PR created automatically by Jules for task [1612903864958602184](https://jules.google.com/task/1612903864958602184) started by @azeez148*