### PR TITLE
Implement Reset Participants API for Campaign V2

### DIFF
--- a/app/api/campaign_v2.py
+++ b/app/api/campaign_v2.py
@@ -118,6 +118,16 @@ async def update_campaign(
         raise HTTPException(status_code=404, detail="Campaign not found")
     return updated
 
+@router.post("/{id}/reset-participants")
+async def reset_campaign_participants(
+    id: str,
+    current_user: User = Depends(get_current_user_admin),
+    db: Session = Depends(get_db)
+):
+    if not campaign_service.reset_participants_v2(db, id):
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    return {"message": "All participants have been removed from the campaign"}
+
 @router.patch("/{id}", response_model=CampaignV2Response)
 async def patch_campaign(
     id: str,

--- a/app/services/campaign.py
+++ b/app/services/campaign.py
@@ -503,6 +503,19 @@ class CampaignService:
             logger.error(f"Error deleting campaign v2: {str(e)}")
             raise e
 
+    def reset_participants_v2(self, db: Session, campaign_id: str) -> bool:
+        try:
+            db_campaign = db.query(CampaignV2).filter(CampaignV2.id == campaign_id).first()
+            if not db_campaign:
+                return False
+            db.query(CampaignParticipation).filter(CampaignParticipation.campaign_id == campaign_id).delete(synchronize_session=False)
+            db.commit()
+            return True
+        except Exception as e:
+            db.rollback()
+            logger.error(f"Error resetting participants for campaign v2: {str(e)}")
+            raise e
+
     def get_campaign_stats_v2(self, db: Session) -> dict:
         total_campaigns = db.query(CampaignV2).count()
         active_campaigns = db.query(CampaignV2).filter(CampaignV2.status == CampaignStatusV2.active).count()

--- a/tests/test_campaign_v2_reset.py
+++ b/tests/test_campaign_v2_reset.py
@@ -1,0 +1,89 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.main import app
+from app.core.database import Base, get_db
+from app.api.auth import get_current_user, get_current_user_admin
+from app.models.campaign import CampaignV2, CampaignStatusV2, CampaignTypeV2, CampaignParticipation
+from app.models.user import User
+import os
+from datetime import datetime, timedelta
+
+# Setup test database
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test_campaign_v2_reset.db"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def override_get_db():
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+def override_get_current_user():
+    return User(id="1", mobile="1234567890", role="admin")
+
+def override_get_current_user_admin():
+    return User(id="1", mobile="1234567890", role="admin")
+
+app.dependency_overrides[get_db] = override_get_db
+app.dependency_overrides[get_current_user] = override_get_current_user
+app.dependency_overrides[get_current_user_admin] = override_get_current_user_admin
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    # Seed a campaign
+    camp = CampaignV2(
+        id="camp_reset",
+        title="Reset Test",
+        type=CampaignTypeV2.prediction,
+        status=CampaignStatusV2.active,
+        start_date=datetime.now() - timedelta(days=1),
+        end_date=datetime.now() + timedelta(days=1),
+    )
+    db.add(camp)
+
+    # Add a user
+    user = User(id="1", mobile="1234567890", role="admin")
+    db.add(user)
+    db.commit()
+    db.close()
+    yield
+    Base.metadata.drop_all(bind=engine)
+    if os.path.exists("./test_campaign_v2_reset.db"):
+        os.remove("./test_campaign_v2_reset.db")
+
+client = TestClient(app)
+
+def test_reset_participants():
+    # 1. Participate in the campaign
+    payload = {
+        "responses": {"score": "2-1"}
+    }
+    resp = client.post("/api/campaigns/camp_reset/participate", json=payload)
+    assert resp.status_code == 200
+
+    # Verify participation exists in DB
+    db = TestingSessionLocal()
+    count = db.query(CampaignParticipation).filter(CampaignParticipation.campaign_id == "camp_reset").count()
+    assert count == 1
+    db.close()
+
+    # 2. Call reset endpoint
+    resp = client.post("/api/campaigns/camp_reset/reset-participants")
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "All participants have been removed from the campaign"
+
+    # 3. Verify participation is gone
+    db = TestingSessionLocal()
+    count = db.query(CampaignParticipation).filter(CampaignParticipation.campaign_id == "camp_reset").count()
+    assert count == 0
+    db.close()
+
+def test_reset_non_existent_campaign():
+    resp = client.post("/api/campaigns/non_existent/reset-participants")
+    assert resp.status_code == 404


### PR DESCRIPTION
This PR implements the requested API for resetting campaign participants in the Campaign V2 module. 

Key changes:
1.  **Service Layer**: Added `reset_participants_v2(db, campaign_id)` in `app/services/campaign.py` which deletes all entries from the `campaign_participations` table for the specified campaign.
2.  **API Layer**: Added a new route `POST /{id}/reset-participants` in `app/api/campaign_v2.py`. This endpoint is protected by `get_current_user_admin` dependency.
3.  **Testing**: Created `tests/test_campaign_v2_reset.py` which covers:
    - Successful reset of participants and verification that records are removed from the database.
    - 404 error handling for non-existent campaigns.

Note: Participation and submission counts in V2 are calculated dynamically by the service, so removing the participation records automatically updates the counts returned by the API.

---
*PR created automatically by Jules for task [3537570875703929786](https://jules.google.com/task/3537570875703929786) started by @azeez148*