### PR TITLE
Prioritize Pending Sales in All Sales Retrieval

### DIFF
--- a/app/api/sales.py
+++ b/app/api/sales.py
@@ -1,7 +1,7 @@
 from http.client import HTTPException
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Optional
 
 from app.core.database import get_db
 from app.schemas.sale import SaleCreate, SaleResponse, SaleStatusUpdate, SaleListResponse
@@ -21,9 +21,10 @@ async def add_sale(
 async def get_all_sales(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=500),
+    status: Optional[str] = Query(None),
     db: Session = Depends(get_db)
 ):
-    sales, total = sale_service.get_all_sales(db, skip=skip, limit=limit)
+    sales, total = sale_service.get_all_sales(db, skip=skip, limit=limit, status=status)
     return {
         "items": sales,
         "total": total,

--- a/app/services/sale.py
+++ b/app/services/sale.py
@@ -1,4 +1,4 @@
-from sqlalchemy import func
+from sqlalchemy import func, case
 from sqlalchemy.orm import Session, joinedload, selectinload
 from typing import List, Optional, Dict
 from app.models.sale import Sale, SaleItem
@@ -125,13 +125,25 @@ class SaleService:
     def get_sale(self, db: Session, sale_id: int) -> Optional[Sale]:
         return db.query(Sale).filter(Sale.id == sale_id).first()
 
-    def get_all_sales(self, db: Session, skip: int = 0, limit: int = 100) -> tuple[List[Sale], int]:
+    def get_all_sales(self, db: Session, skip: int = 0, limit: int = 100, status: Optional[str] = None) -> tuple[List[Sale], int]:
         query = db.query(Sale).options(
             joinedload(Sale.customer),
             joinedload(Sale.payment_type),
             joinedload(Sale.delivery_type),
             selectinload(Sale.sale_items),
-        ).order_by(Sale.id.desc())
+        )
+
+        if status:
+            query = query.filter(Sale.status == status).order_by(Sale.id.desc())
+        else:
+            # When no status is provided, show PENDING first, then others in descending order
+            query = query.order_by(
+                case(
+                    (Sale.status == SaleStatus.PENDING, 0),
+                    else_=1
+                ),
+                Sale.id.desc()
+            )
 
         total = query.count()
         sales = query.offset(skip).limit(limit).all()

--- a/tests/test_sale_ordering.py
+++ b/tests/test_sale_ordering.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.models.base import Base
+from app.models.sale import Sale
+from app.schemas.enums import SaleStatus
+from app.services.sale import SaleService
+
+class TestSaleOrdering(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Use SQLite for testing
+        cls.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(cls.engine)
+        cls.SessionLocal = sessionmaker(bind=cls.engine)
+
+    def setUp(self):
+        self.db = self.SessionLocal()
+        self.sale_service = SaleService()
+        # Clean up sales table before each test
+        self.db.query(Sale).delete()
+        self.db.commit()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_get_all_sales_default_ordering(self):
+        # Create sales in mixed order of ID and status
+        # IDs will be assigned automatically by SQLite starting from 1
+        sales_to_create = [
+            Sale(id=1, date="2023-01-01", total_quantity=1, total_price=10.0, payment_type_id=1, delivery_type_id=1, shop_id=1, status=SaleStatus.COMPLETED),
+            Sale(id=2, date="2023-01-02", total_quantity=1, total_price=20.0, payment_type_id=1, delivery_type_id=1, shop_id=1, status=SaleStatus.PENDING),
+            Sale(id=3, date="2023-01-03", total_quantity=1, total_price=30.0, payment_type_id=1, delivery_type_id=1, shop_id=1, status=SaleStatus.SHIPPED),
+            Sale(id=4, date="2023-01-04", total_quantity=1, total_price=40.0, payment_type_id=1, delivery_type_id=1, shop_id=1, status=SaleStatus.PENDING),
+            Sale(id=5, date="2023-01-05", total_quantity=1, total_price=50.0, payment_type_id=1, delivery_type_id=1, shop_id=1, status=SaleStatus.CANCELLED),
+        ]
+        self.db.add_all(sales_to_create)
+        self.db.commit()
+
+        # NEW BEHAVIOR: PENDING first, then by ID descending
+        # Pending IDs are 4 and 2. 4 > 2, so [4, 2]
+        # Remaining IDs are 5, 3, 1. Sorted desc: [5, 3, 1]
+        # Total expected: [4, 2, 5, 3, 1]
+        sales, total = self.sale_service.get_all_sales(self.db)
+        ids = [s.id for s in sales]
+        statuses = [s.status for s in sales]
+        print(f"New ordering ids: {ids}")
+        print(f"New ordering statuses: {statuses}")
+        self.assertEqual(ids, [4, 2, 5, 3, 1])
+        self.assertEqual(statuses[0], SaleStatus.PENDING)
+        self.assertEqual(statuses[1], SaleStatus.PENDING)
+
+    def test_get_all_sales_with_status_filter(self):
+        sales_to_create = [
+            Sale(id=1, date="2023-01-01", total_quantity=1, total_price=10.0, payment_type_id=1, delivery_type_id=1, shop_id=1, status=SaleStatus.COMPLETED),
+            Sale(id=2, date="2023-01-02", total_quantity=1, total_price=20.0, payment_type_id=1, delivery_type_id=1, shop_id=1, status=SaleStatus.PENDING),
+            Sale(id=3, date="2023-01-03", total_quantity=1, total_price=30.0, payment_type_id=1, delivery_type_id=1, shop_id=1, status=SaleStatus.COMPLETED),
+        ]
+        self.db.add_all(sales_to_create)
+        self.db.commit()
+
+        sales, total = self.sale_service.get_all_sales(self.db, status=SaleStatus.COMPLETED)
+        ids = [s.id for s in sales]
+        self.assertEqual(ids, [3, 1])
+        self.assertEqual(total, 2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This change modifies the sales retrieval logic to meet the requirement of displaying pending sales first in the default view. 

Key changes:
1.  **Service Layer**: `SaleService.get_all_sales` now accepts an optional `status` parameter. If no status is provided, it uses SQLAlchemy's `case` statement to sort `PENDING` sales at the top, with a secondary sort by ID in descending order.
2.  **API Layer**: The `/api/sales/all` endpoint was updated to accept the `status` query parameter.
3.  **No Duplicates**: The implementation uses a single query with combined ordering to ensure that all sales are returned exactly once.
4.  **Testing**: A new test file `tests/test_sale_ordering.py` was added, using an in-memory SQLite database to confirm the ordering behavior and filtering functionality. Existing tests were also verified to pass.

---
*PR created automatically by Jules for task [1823149103633129853](https://jules.google.com/task/1823149103633129853) started by @azeez148*